### PR TITLE
EPGImport: do not try fake recording for services containing url

### DIFF
--- a/src/EPGImport/plugin.py
+++ b/src/EPGImport/plugin.py
@@ -183,6 +183,9 @@ def channelFilter(ref):
 	if refstr in serviceIgnoreList:
 		print>>log, "Serviceref is in ignore list:", refstr
 		return False
+	if "%3a//" in ref.lower():
+		print>>log, "URL detected in serviceref, not checking fake recording on serviceref:", ref
+		return True
 	fakeRecService = NavigationInstance.instance.recordService(sref, True)
 	if fakeRecService:
 		fakeRecResult = fakeRecService.start(True)


### PR DESCRIPTION
This commit allows using service references other than 1:0:1 on custom channels.

Previously it could work only for 4097 and servicemp3, but once serviceapp was used
the following error occured:

[EPGImport] Parsing channels from '/etc/epgimport/MyTest.channels.xml'
[eNavigation] record: -1
record returned non-zero
Invalid serviceref string: 4097:0:1:A0A2:0:0:0:0:0:3:http%3a//...m3u8:Radio Contact Vision HD

That is happening because serviceapp, doesn't support recording yet.

So instead of adding fake recording on serviceapp/hisi/... we can simply disable the check when
URL detected on service reference.

Finally the instructions in https://forums.openpli.org/topic/47658-epg-for-iptv-channels/
must change since "Also the 4097 has to be replaced by a 1" is not valid any more.

Any service referene on channel should work now, as long as there is a url included.

Related: https://devtools.openpli.org/issues/283