### PR TITLE
Add new attribute nocheck="1" to avoid the LastUpdate.log check

### DIFF
--- a/src/EPGImport/EPGConfig.py
+++ b/src/EPGImport/EPGConfig.py
@@ -103,6 +103,13 @@ class EPGChannel:
 class EPGSource:
 	def __init__(self, path, elem, category=None):
 		self.parser = elem.get('type')
+		nocheck = elem.get('nocheck')
+		if nocheck == None:
+			self.nocheck = 0
+		elif nocheck == "1":
+			self.nocheck = 1
+		else:
+			self.nocheck = 0
 		self.urls = [e.text.strip() for e in elem.findall('url')]
 		self.url = random.choice(self.urls)
 		self.description = elem.findtext('description')
@@ -171,7 +178,7 @@ if __name__ == '__main__':
 	if len(sys.argv) > 1:
 		path = sys.argv[1]
 	for p in enumSources(path):
-		t = (p.description, p.urls, p.parser, p.format, p.channels)
+		t = (p.description, p.urls, p.parser, p.format, p.channels, p.nocheck)
 		l.append(t)
 		print t
 		x.append(p.description)
@@ -179,7 +186,7 @@ if __name__ == '__main__':
 	assert loadUserSettings('settings.pkl') == {"sources": [1,"twee"]}
 	os.remove('settings.pkl')
 	for p in enumSources(path, x):
-		t = (p.description, p.urls, p.parser, p.format, p.channels)
+		t = (p.description, p.urls, p.parser, p.format, p.channels, p.nocheck)
 		assert t in l
 		l.remove(t)
 	assert not l

--- a/src/EPGImport/EPGImport.py
+++ b/src/EPGImport/EPGImport.py
@@ -416,8 +416,13 @@ class EPGImport:
 			filename += ext
 		sourcefile = sourcefile.encode('utf-8')
 		print>>log, "[EPGImport] Downloading: " + sourcefile + " to local path: " + filename
-		if self.checkValidServer(sourcefile) == 1:
+		if self.source.nocheck == 1:
+			print>>log, "[EPGImport] Not cheching the server since nocheck is set for it: " + sourcefile
 			downloadPage(sourcefile, filename).addCallbacks(afterDownload, downloadFail, callbackArgs=(filename,True))
 			return filename
 		else:
-			self.downloadFail("checkValidServer reject the server")
+			if self.checkValidServer(sourcefile) == 1:
+				downloadPage(sourcefile, filename).addCallbacks(afterDownload, downloadFail, callbackArgs=(filename,True))
+				return filename
+			else:
+				self.downloadFail("checkValidServer reject the server")

--- a/src/EPGImport/plugin.py
+++ b/src/EPGImport/plugin.py
@@ -184,7 +184,7 @@ def channelFilter(ref):
 		print>>log, "Serviceref is in ignore list:", refstr
 		return False
 	if "%3a//" in ref.lower():
-		print>>log, "URL detected in serviceref, not checking fake recording on serviceref:", ref
+		# print>>log, "URL detected in serviceref, not checking fake recording on serviceref:", ref
 		return True
 	fakeRecService = NavigationInstance.instance.recordService(sref, True)
 	if fakeRecService:


### PR DESCRIPTION
Data validity on server are checked by controlling the LastUpdate.log file.

If you need to avoid this check, it is now possible to include the attribute:
nocheck="1"
Exemple:
<source type="gen_xmltv" nocheck="1" channels="rytec.channels.xml.xz">

But we strongly recommend not to use this attribute but ensure to have the
LastUpdate.log created once all the files are properly updated.
Date format to use in this file is: "%Y-%m-%d"