### PR TITLE
EPGImport will now read the content of the file:  /etc/epgimport/cust…

### DIFF
--- a/src/EPGImport/EPGConfig.py
+++ b/src/EPGImport/EPGConfig.py
@@ -60,7 +60,8 @@ class EPGChannel:
 		return fd
 	def parse(self, filterCallback, downloadedFile):
 		print>>log,"[EPGImport] Parsing channels from '%s'" % self.name
-		self.items = {}
+		if self.items is None:
+			self.items = {}
 		try:
 			context = iterparse(self.openStream(downloadedFile))
 			for event, elem in context:
@@ -80,6 +81,12 @@ class EPGChannel:
 			print>>log, "[EPGImport] failed to parse", downloadedFile, "Error:", e
 			pass
 	def update(self, filterCallback, downloadedFile=None):
+		customFile='/etc/epgimport/custom.channels.xml'
+		# Always read custom file since we don't know when it was last updated
+		# and we don't have multiple download from server problem since it is always a local file.
+		if os.path.exists(customFile):
+			print>>log,"[EPGImport] Parsing channels from '%s'" % customFile
+			self.parse(filterCallback, customFile)
 		if downloadedFile is not None:
 			self.mtime = time.time()
 			return self.parse(filterCallback, downloadedFile)


### PR DESCRIPTION
…om.channels.xml.

All the channels included in this file will be added to every possible channels source
that are defined in a xxx.sources.xml.

So you now longer need to create your own custom "xxx.sources.xml" files into
/etc/epgimport/

If you defined your own userbouquet file (or favorite file), you need to define a unique
service reference:

4097:0:1:Index:0:0:0:0:0:3:http%3A...

Where :Index: is a unique hexadecimal value different for every possible channels assigned
 by you.

The custom.channel.xml file has this structure:

<?xml version="1.0" encoding="latin-1"?>
<channels>
	<channel id="MyChannel.cc">4097:0:1:Index:0:0:0:0:0:3:http%3A//...</channel>  <!-- MyChannel -->
	...
</channels>

The "MyChannel.cc" must exist in one of the source file you will select to get EPG.
You need to have a logical match between the :Index: you create and the "MyChannel.cc"

You retrieve the MyChannel.cc in this file:

http://epgalfasite.dyndns.tv/rytec.channels.xlsx

If you can receive several times the same channel, you can of course reuse the same
reference.

Or you can reuse an existing satellite unique reference but the very beginning must match
the one defined in your userbouquet, so if your userbouquet is created for 4097: you need
to change the reference from 1: to 4097:

Step 1: Create your custom.channels.xml

Step 2: Place it into the /etc/epgimport/ folder on your STB

Step 3: In EPGImport press blue to select the sources that you need
		(the same ones used for satellite that contain the MyChanel.cc EPG info)

Step 4: In EPGImport Press Yellow button manual import

Real exemple:

In my userbouquet I have this:

So I check in the .xlsx file and I find that Radio Contact is called:
RadioContactVision.be

so in my custom.channels.xml I add this:

	<channel id="RadioContactVision.be">4097:0:1:A095:0:0:0:0:0:3:http%3a//contact-lh.akamaihd.net/i/CONTACT_1%40321283/index_1800_av-p.m3u8:Radio Contact Vision HD</channel>  <!-- Radio Contact Vision -->

And for source I select:

	Wallonie - Telesat Base (xz)

Remark:
If you want to reuse the reference found in the rytec.channels.xlsx file please change:
1:0:1:2909:69:1:FFFF0000:0:0:0:

into:

4097:0:1:2909:69:1:FFFF0000:0:0:0:

My #SERVICE start with 4097 so it must match between the userbouquet and the
custom.channels.xml

Enjoy!