### PR TITLE
Change LastUpdate.log into LastUpdate.txt

### DIFF
--- a/src/EPGImport/EPGImport.py
+++ b/src/EPGImport/EPGImport.py
@@ -23,7 +23,7 @@ from datetime import datetime
 date_format = "%Y-%m-%d"
 now = datetime.now()
 alloweddelta = 2
-CheckFile = "LastUpdate.log"
+CheckFile = "LastUpdate.txt"
 ServerStatusList = {}
 
 PARSERS = {


### PR DESCRIPTION
A mirror is unable to provide file with .log extension, so we decide to change the LastUpdate.log into LastUpdate.txt