### PR TITLE
Display progress message when filtering per favourites is active

### DIFF
--- a/src/EPGImport/locale/EPGImport.pot
+++ b/src/EPGImport/locale/EPGImport.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:40+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,78 +25,102 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr ""
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr ""
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr ""
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr ""
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr ""
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr ""
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr ""
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr ""
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr ""
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr ""
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr ""
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr ""
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr ""
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr ""
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr ""
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr ""
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr ""
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr ""
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr ""
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr ""
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr ""
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
 msgstr ""
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -103,139 +128,188 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
 msgstr ""
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr ""
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr ""
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr ""
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr ""
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr ""
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr ""
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr ""
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr ""
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr ""
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr ""
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr ""
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr ""
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr ""
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr ""
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr ""
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr ""
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr ""
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr ""
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr ""
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr ""
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr ""
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr ""
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr ""
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr ""
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr ""
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr ""
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr ""
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr ""
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr ""
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr ""
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
 msgstr ""
 
+#: ../plugin.py:51
 msgid "always"
 msgstr ""
 
+#: ../plugin.py:54
 msgid "never"
 msgstr ""
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr ""
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr ""
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr ""
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr ""

--- a/src/EPGImport/locale/cs.po
+++ b/src/EPGImport/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: enigma2-plugins 3.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2012-05-17 14:10+0000\n"
 "Last-Translator: jerry\n"
 "Language-Team: jerry\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,89 +25,113 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr ""
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr ""
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr ""
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr ""
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr ""
 
 #
+#: ../plugin.py:336
 #, fuzzy
 msgid "Automatic import EPG"
 msgstr "Denní automatický import"
 
 #
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Čas automatického spuštění"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr ""
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr ""
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr ""
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr ""
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr ""
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr ""
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr ""
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr ""
 
 #
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Nastavení importu EPG"
 
 #
+#: ../plugin.py:681
 #, fuzzy
 msgid "EPG Import Log"
 msgstr "Zdroje importu EPG"
 
 #
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Zdroje importu EPG"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr ""
 
 #
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "Zdroje importu EPG"
 
 #
+#: ../plugin.py:1046 ../plugin.py:1061
 #, fuzzy
 msgid "EPGImport"
 msgstr "Zdroje importu EPG"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
 msgstr ""
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -114,155 +139,204 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
 msgstr ""
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr ""
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr ""
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
 #
+#: ../plugin.py:547
 #, fuzzy
 msgid "Import current source"
 msgstr "Zdroje importu EPG"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr ""
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr ""
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr ""
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr ""
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
 #
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Načíst dlouhé popisy po X dnech"
 
 #
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Ručně"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr ""
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr ""
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr ""
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr ""
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr ""
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr ""
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr ""
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr ""
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr ""
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr ""
 
 #
+#: ../plugin.py:346
 #, fuzzy
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Zobrazit v zozšířeních"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr ""
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr ""
 
 #
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Zdroje"
 
 #
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Uspat po spuštění"
 
 #
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Importovat po nabootování"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr ""
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr ""
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr ""
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr ""
 
 #
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Při vypnutém stavu"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
 msgstr ""
 
+#: ../plugin.py:51
 msgid "always"
 msgstr ""
 
+#: ../plugin.py:54
 msgid "never"
 msgstr ""
 
 #
+#: ../plugin.py:53
 #, fuzzy
 msgid "only automatic boot"
 msgstr "Denní automatický import"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr ""
 
 #
+#: ../plugin.py:62
 #, fuzzy
 msgid "skip the import"
 msgstr "Přeskočit import"
 
 #
+#: ../plugin.py:61
 #, fuzzy
 msgid "wake up and import"
 msgstr "Probudit a stáhnout"

--- a/src/EPGImport/locale/de.po
+++ b/src/EPGImport/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2016-04-09 19:09+0200\n"
 "Last-Translator: edcrane\n"
 "Language-Team: none\n"
@@ -18,6 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -29,74 +30,97 @@ msgstr ""
 "wird bis zu einigen Minuten dauern.\n"
 "Ist das OK?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " Ereignisse\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Sender hinzufügen"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Senderkette hinzufügen"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Alle Senderketten"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automatisierter EPG-Import"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "EPG automatisch importieren"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Startzeit"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Abbrechen"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Kanalauswahl"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Nur an bestimmten Tagen importieren"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Löschen"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "EPG vor dem Import löschen"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Ausgewählte Tage berücksichtigen"
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Import an bestimmten Tagen"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Alle löschen"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Ausgewählte löschen"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "EPG-Import-Konfiguration"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG-Import-Log"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "EPG-Import-Quellen"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG-Import abgeschlossen, %d Ereignisse"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -104,6 +128,7 @@ msgstr ""
 "EPGImport\n"
 "Import der EPG-Daten läuft noch. Bitte warten."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -115,6 +140,7 @@ msgstr ""
 "wird bis zu einigen Minuten dauern.\n"
 "Ist das OK?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -122,18 +148,30 @@ msgstr ""
 "EPGImport Plugin\n"
 "Nicht gestartet:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Freitag"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Liste der zu überspringenden Sender"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Liste der zu überspringenden Sender (OK zum Speichern)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Aktuelle Quelle importieren"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -142,93 +180,122 @@ msgstr ""
 "Importiere: %s\n"
 "%s Ereignisse"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Letzter Import: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Letzter Import: %s Ereignisse"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Letzte: %s %s, %d Ereignisse"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "EPG nur für Sender aus Favoritenlisten aktualisieren"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Lade lange Beschreibungen bis zu X Tage"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manuell"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Montag"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Keine aktiven EPG-Quellen gefunden, nichts zu tun"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "OK drücken"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Wirklich die gesamte Liste löschen?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Nach Import in den Tiefschlaf zurückkehren"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Nach Import AutoTimer starten"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Samstag"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Sichern"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Aktion auswählen"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "\"EPG-Importer\" im Hauptmenü anzeigen"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "\"EPG-Import\" unter Erweiterungen anzeigen"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Log anzeigen"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Import bei GUI-Neustart überspringen"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Quellen"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Standby beim Start"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Import nach dem Booten starten"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Sonntag"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Donnerstag"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Dienstag"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Mittwoch"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Wenn ausgeschaltet"
 
+#: ../plugin.py:687
 #, fuzzy
 msgid "Write to /tmp/epgimport.log"
 msgstr "Nach /tmp/EPGimport.log schreiben"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -236,6 +303,7 @@ msgstr ""
 "Sie können diese Einstellung nicht nutzen!\n"
 "Mindestens ein Tag muß ausgewählt sein!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -243,20 +311,26 @@ msgstr ""
 "Sie müssen Enigma2 neu starten, um die EPG-Daten zu laden\n"
 "Ist das ok?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "immer"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "niemals"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "Nur bei automatischem Neustart"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "Nur bei manuellem Neustart"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "Import überspringen"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "Aufwachen und importieren"

--- a/src/EPGImport/locale/el.po
+++ b/src/EPGImport/locale/el.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPG Import\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: \n"
 "Last-Translator: MCelliot_g <mcelliot_g@hotmail.com>\n"
 "Language-Team: \n"
@@ -12,6 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -23,73 +24,96 @@ msgstr ""
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά.\n"
 "Είναι αυτό εντάξει;"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " προγράμματα\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Προσθήκη Καναλιού"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Προσθήκη Παρόχου"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Πάροχος όλων των υπηρεσιών"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Αυτοματοποιημένη Eισαγωγή EPG"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Αυτόματη εισαγωγή EPG"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Αυτόματη ώρα έναρξης"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Ακύρωση"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Επιλογή Καναλιών"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Επιλογή ημερών για εκκίνηση εισαγωγής"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Καθαρισμός"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Καθαρισμός τρέχοντος EPG πριν την εισαγωγή"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Υπενθύμιση ρύθμισης του \"Προφίλ Ημερών\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Προφίλ Ημερών"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Διαγραφή όλων"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Διαγραφή επιλεγμένων"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Ρυθμίσεις Εισαγωγής EPG"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Καταγραφή Εισαγωγής EPG"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Πηγές Εισαγωγής EPG"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Η εισαγωγή EPG ολοκληρώθηκε, %d προγράμματα"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "Εισαγωγή EPG"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "Εισαγωγή EPG"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -97,6 +121,7 @@ msgstr ""
 "Εισαγωγή EPG\n"
 "Η εισαγωγή των δεδομένων EPG είναι ακόμα σε εξέλιξη. Περιμένετε..."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -108,6 +133,7 @@ msgstr ""
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά.\n"
 "Είναι αυτό εντάξει;"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -115,18 +141,30 @@ msgstr ""
 "Πρόσθετο EPGImport\n"
 "Αδυναμία εκκίνησης:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Παρασκευή"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Αγνόηση λίστας υπηρεσιών"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Αγνόηση λίστας υπηρεσιών (πιέστε ΟΚ για αποθήκευση)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Εισαγωγή τρέχουσας πηγής"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -135,92 +173,121 @@ msgstr ""
 "Εισαγωγή σε εξέλιξη: %s\n"
 "%s προγράμματα"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Τελευταία εισαγωγή: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Τελευταία εισαγωγή: %s προγράμματα"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Τελευταίο: %s %s, %d προγράμματα"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Φόρτωση μόνο υπηρεσιών με EPG στα μπουκέτα"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Φόρτωση εκτεταμένων περιγραφών έως και Χ ημέρες"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Χειροκίνητα"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Δευτέρα"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Δεν βρέθηκαν ενεργές πηγές EPG, καμία ενέργεια"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Πιέστε ΟΚ"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Να διαγραφούν σίγουρα όλες οι λίστες;"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Επιστροφή σε βαθιά αναμονή μετά την εισαγωγή"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Εκτέλεση Αυτόματου Χρονοδιακόπτη μετά την εισαγωγή"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Σάββατο"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Αποθήκευση"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Επιλογή ενέργειας"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Εμφάνιση της \"Εισαγωγής EPG\" στο κύριο μενού"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Εμφάνιση της \"Εισαγωγής EPG\" στις επεκτάσεις"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Εμφάνιση καταγραφής"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Παράκαμψη εισαγωγής κατά την επανεκκίνηση του GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Πηγές"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Αναμονή κατά την εκκίνηση"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Έναρξη εισαγωγής μετά την εκκίνηση"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Κυριακή"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Πέμπτη"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Τρίτη"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Τετάρτη"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Σε βαθιά αναμονή"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Εγγραφή στο /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -228,6 +295,7 @@ msgstr ""
 "Μπορείτε να μη χρησιμοποιήσετε αυτές τις ρυθμίσεις!\n"
 "Πρέπει να συμπεριλαμβάνεται τουλάχιστον μία ημέρα της εβδομάδας!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -235,20 +303,26 @@ msgstr ""
 "Το Enigma2 πρέπει να επανεκκινηθεί για να φορτωθούν\n"
 "τα δεδομένα EPG, είναι αυτό εντάξει;"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "πάντα"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "ποτέ"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "μόνο αυτόματη εκκίνηση"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "μόνο χειροκίνητη εκκίνηση"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "παράκαμψη εισαγωγής"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "αφύπνιση και εισαγωγή"

--- a/src/EPGImport/locale/en_GB.po
+++ b/src/EPGImport/locale/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2012-03-05 22:57+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../plugin.py:703
 #, fuzzy
 msgid ""
 "\n"
@@ -29,76 +30,99 @@ msgstr ""
 "This may take a few minutes\n"
 "Is this ok?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr ""
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr ""
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr ""
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr ""
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automated EPG Importer"
 
+#: ../plugin.py:336
 #, fuzzy
 msgid "Automatic import EPG"
 msgstr "Daily automatic import"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Automatic start time"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Cancel"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr ""
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr ""
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Clear"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr ""
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr ""
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr ""
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr ""
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "EPG Import Configuration"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG Import Log"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "EPG Import Sources"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG Import finished, %d events"
 
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:451
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -107,6 +131,7 @@ msgstr ""
 "EPGImport Plugin\n"
 "Import of epg data is still in progress. Please wait."
 
+#: ../plugin.py:467
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -119,6 +144,7 @@ msgstr ""
 "This may take a few minutes\n"
 "Is this ok?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -126,117 +152,159 @@ msgstr ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr ""
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr ""
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
+#: ../plugin.py:547
 #, fuzzy
 msgid "Import current source"
 msgstr "EPG Import Sources"
 
+#: ../plugin.py:300
 #, fuzzy, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr "EPG Import finished, %d events"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr ""
 
+#: ../plugin.py:446
 #, fuzzy, python-format
 msgid "Last import: %s events"
 msgstr "Last: %s %s, %d events"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Last: %s %s, %d events"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Load long descriptions up to X days"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manual"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr ""
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "No active EPG sources found, nothing to do"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr ""
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr ""
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr ""
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr ""
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr ""
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Save"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr ""
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr ""
 
+#: ../plugin.py:346
 #, fuzzy
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Show in extensions"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr ""
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr ""
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Sources"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Standby at startup"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Start import after booting up"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr ""
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr ""
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr ""
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr ""
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "When in deep standby"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -244,23 +312,29 @@ msgstr ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr ""
 
+#: ../plugin.py:54
 msgid "never"
 msgstr ""
 
+#: ../plugin.py:53
 #, fuzzy
 msgid "only automatic boot"
 msgstr "Daily automatic import"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr ""
 
+#: ../plugin.py:62
 #, fuzzy
 msgid "skip the import"
 msgstr "Skip the import"
 
+#: ../plugin.py:61
 #, fuzzy
 msgid "wake up and import"
 msgstr "Wake up and import"

--- a/src/EPGImport/locale/es.po
+++ b/src/EPGImport/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-22 18:17+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2018-05-22 18:19+0200\n"
 "Last-Translator: Javier Sayago <admin@lonasdigital.com>\n"
 "Language-Team: OpenLD\n"
@@ -18,6 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.7\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -29,73 +30,96 @@ msgstr ""
 "Esto puede tomar unos pocos minutos.\n"
 "¿Es correcto?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " Eventos\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Agregar canal"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Agregar proveedor"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Todos los proveedores de servicios"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automatizar EPG-Import"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Importar EPG automáticamente"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Hora del inicio automático"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Selección del canal"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Días de elección para la importación inicial"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Borrar"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Eliminar EPG antes de importar"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Considerar los días seleccionados"
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Importación en ciertos días"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Eliminar todos"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Eliminar seleccionado"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Configuración EPG-Import"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG-Import-Log"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "EPG-Import-Fuentes"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG-Import terminó, %d Eventos"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -103,6 +127,7 @@ msgstr ""
 "EPGImport\n"
 "La importación de los datos EPG está en curso. Por favor, espere."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -114,6 +139,7 @@ msgstr ""
 "Esto puede tardar unos minutos.\n"
 "¿Está conforme?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -121,18 +147,30 @@ msgstr ""
 "EPGImport Plugin\n"
 "Error al iniciar:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Viernes"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Ignorar lista de servicios"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorar lista de servicios (presione OK para guardar)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importar fuente actual"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -141,92 +179,121 @@ msgstr ""
 "Importación: %s\n"
 "%s Eventos"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Última importación:: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Última importación: %s Eventos"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Último: %s %s, %d Eventos"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Cargar servicios de EPG únicamente en bouquets"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Cargar descripciones largas hasta X días"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manual"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Lunes"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "No se encontraron fuentes de EPG activas, nada que hacer"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Pulse OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "¿Realmente elimina toda la lista?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Volver al modo de espera profundo después de la importación"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Ejecutar AutoTimer después de importar"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Sábado"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Guardar"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Seleccionar acción"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Mostrar \"EPG Importer\" en el menú principal"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Mostrar \"EPG Importer\" en extensiones"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Mostrar log"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Omitir importación al reiniciar GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Fuentes"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "En espera al inicio"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Iniciar importación después de arrancar"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Domingo"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Jueves"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Martes"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Miércoles"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Cuando está en modo de espera profundo"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Escribir en /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -234,6 +301,7 @@ msgstr ""
 "¡No puedes usar esta configuración!\n"
 "Por lo menos un día a la semana debe ser incluido."
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -241,20 +309,26 @@ msgstr ""
 "Debe reiniciar Enigma2 para cargar los datos EPG\n"
 "¿Está conforme?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "siempre"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "nunca"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "Sólo arranque automático"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "Sólo arranque manual"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "Omitir la importación"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "Despertar e importar"

--- a/src/EPGImport/locale/et.po
+++ b/src/EPGImport/locale/et.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: XMTV-Impoter for Enigma2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2017-08-30 12:21+0300\n"
 "Last-Translator: rimas\n"
 "Language-Team: rimas\n"
@@ -14,6 +14,7 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Generator: Poedit 2.0.3\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -25,73 +26,96 @@ msgstr ""
 "See võib kesta mõne minuti\n"
 "Kas see sobib?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " saadet\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Lisa kanal"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Lisa levitaja"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Levitaja kõigile kanalitele"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automaatne EPG import"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Hangi EPG automaatselt"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Automaatse käivituse aeg"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Tühista"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Kanalivalik"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Päev EPG hankimiseks"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Kustuta"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Aktiivse EPG eemaldamine enne importi"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Seadista \"päevade profiil\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Päevade profiil"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Kustuta  kõik"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Kustuta valik"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Seadistamine"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG impordi logi"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "EPG impordi allikad"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG hankimine lõpetatud, %d saadet"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "EPG import"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPGImport"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -99,6 +123,7 @@ msgstr ""
 "EPG import\n"
 "Epg hankimine on pooleli. Oota."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -110,6 +135,7 @@ msgstr ""
 "See võib kesta mõne minuti\n"
 "Kas see sobib?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -117,18 +143,30 @@ msgstr ""
 "EPGImport\n"
 "Käivitamine nurjus:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Reede"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Eiratav kanalinimekiri"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Eiratav (salvestamiseks vajuta OK)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Import valitud allikast"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -137,92 +175,121 @@ msgstr ""
 "Import: %s\n"
 "%s saadet"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Viimati: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Viimati: %s saadet"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Viimati: %s %s, %d saadet"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "EPG ainult kanalitele lemmiknimekirjades"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Pikk saatetutvustus X päevaks"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Käsitsi"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Esmaspäev"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "EPG allikad on määramata. Midagi ei saa teha"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Vajuta OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Kas kustutada kogu nimekiri?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Pärast importi tagasi puhkeseisundisse"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Käivita Autotaimer pärast importi"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Laupäev"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Salvesta"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Vali tegevus"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Kuva \"EPG import\" peamenüüs"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Kuva \"EPG import\" laienduste menüüs"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Kuva logi"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Ära impordi pärast E2 taaskäivitust"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Allikad"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Käivitamine ooteseisundist"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Hangi EPG pärast alglaadimist"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Pühapäev"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Neljapäev"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Teisipäev"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Kolmapäev"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Puhkeseisundis"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Kirjuta /tmp/epgimport.log  faili"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -230,6 +297,7 @@ msgstr ""
 "Seda seadistust ei saa kasutada!\n"
 "Tuleb valida vähemalt üks päev või nädal!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -237,20 +305,26 @@ msgstr ""
 "EPG laadimiseks tuleb Enigma2 taaskäivitada.\n"
 "Kas see sobib?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "alati"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "mitte kunagi"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "ainult automaatsel alglaadimisel"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "ainult käsitsi alglaadimisel"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "ära hangi"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "käivita ja impordi"

--- a/src/EPGImport/locale/fi.po
+++ b/src/EPGImport/locale/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2016-05-17 12:41+0200\n"
 "Last-Translator: Samzam <http://www.world-of-satellite.com>\n"
 "Language-Team: none\n"
@@ -18,6 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.7\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -29,74 +30,97 @@ msgstr ""
 "Tämä voi kestää muutaman minuutin.\n"
 "Onko tämä OK?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " tapahtumia\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr ""
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr ""
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr ""
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automaattinen EPG:n lataus"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Automaattinen EPG lataus"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Aloitusaika"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Poistu"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr ""
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Valitse latauspäivät"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Tyhjennä"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Tyhjennä nykyinen EPG ennen latausta"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Harkitse asetusta \"Valitse päivät\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Valitse päivät"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr ""
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr ""
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Asetukset"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Loki"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Lähteet"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Lataus valmis, %d tapahtumaa"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "EPG:n lataus"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG:n lataus"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -104,6 +128,7 @@ msgstr ""
 "EPG:n lataus\n"
 "EPG:n lataus käynnissä. Odota."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -115,6 +140,7 @@ msgstr ""
 "Tämä voi kestää muutaman minuutin.\n"
 "Onko tämä OK?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -122,18 +148,30 @@ msgstr ""
 "EPG lataus\n"
 " Käynnistys epäonnistui:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Perjantai"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr ""
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Lataa tämä lähde"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -142,93 +180,122 @@ msgstr ""
 "Lataa: %s\n"
 "%s events"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Viimeisin lataus: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Viimeisin lataus: %s tapahtumaa"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Ladattu: %s %s, %d tapahtumaa"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Lataa EPG vain suosikkilistojen kanaville"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Lataa ohjelmakuvaukset X päivälle"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Lataa nyt"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Maanantai"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Ei löytynyt aktiivisia EPG lähteitä"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Paina OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr ""
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Palaa virransäästötilaan latauksen jälkeen"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Käynnistä automaattiajastusten haku latauksen jälkeen"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Lauantai"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Tallenna"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr ""
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Näytä \"EPG:n lataus\" päävalikossa"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Näytä \"EPG:n lataus\" laajennusvalikossa"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr ""
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Ohita lataus uudelleenkäynnistyksessä"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Lähteet"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Valmiustilassa lataus"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Lataa uudelleenkäynnistyksen jälkeen"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Sunnuntai"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Torstai"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Tiistai"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Keskiviikko"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Virransäästötilassa lataus"
 
+#: ../plugin.py:687
 #, fuzzy
 msgid "Write to /tmp/epgimport.log"
 msgstr "Kirjoita lokiin /tmp/EPGimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -236,6 +303,7 @@ msgstr ""
 "Et voi käyttää tätä asetusta!\n"
 "Vähintään yksi päivä pitää valita!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -243,20 +311,26 @@ msgstr ""
 "Enigma2 on uudelleenkäynnistettävä,\n"
 " OK?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "aina"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "ei koskaan"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "vain automaattisessa uudelleenkäynnistyksessä"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "vain manuaalisessa uudelleenkäynnistyksessä"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "ohita lataus"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "herätä ja lataa"

--- a/src/EPGImport/locale/fr.po
+++ b/src/EPGImport/locale/fr.po
@@ -2,16 +2,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
-"PO-Revision-Date: 2018-05-03 15:34+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
+"PO-Revision-Date: 2019-01-01 00:43+0100\n"
 "Last-Translator: demosat\n"
 "Language-Team: LANGUAGE <dummy@dummy.fr>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.7\n"
+"X-Generator: Poedit 2.2\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -23,73 +24,96 @@ msgstr ""
 "Cela va durer quelques minutes.\n"
 "Êtes-vous d'accord ?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " évènements\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Ajouter une chaîne"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Ajouter un fournisseur"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Tous les services du fournisseur"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Importation EPG automatique"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Importation EPG automatique"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Heure de démarrage automatique"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Annuler"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Sélection des chaînes"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Choisir les jours pour démarrer l’import"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Effacer"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Effacer l'EPG actuel avant l'importation"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Considérer le profil « Profil des jours »"
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Profil des jours"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Tout effacer"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Effacer les sélectionner"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Configuration EPG import"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Log EPG Import"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Sources pour EPG Import"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG Import terminé, %d évènements"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "EPG Importer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPGImport"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -97,6 +121,7 @@ msgstr ""
 "EPGImport Plugin\n"
 "L'import des données EPG est encore en cours. Merci de patienter."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -108,6 +133,7 @@ msgstr ""
 "Cela va durer quelques minutes.\n"
 "Êtes-vous d'accord ?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -115,18 +141,32 @@ msgstr ""
 "EPGImport Plugin\n"
 "Echec du démarrage:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+"Filtrage: %s\n"
+"Merci de patienter!"
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Vendredi"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Liste des services à ignorer"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Liste des services à ignorer (appuyez sur OK pour sauvegarder)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importer la source actuelle"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -135,92 +175,121 @@ msgstr ""
 "Importation: %s\n"
 "%s évènements"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Dernier import:"
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Dernier import: %s évènements"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Dernier: %s %s, %d évènements"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Charger EPG uniquements pour les favoris"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Charger les descriptions longues jusqu'à X jours"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manuel"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Lundi"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Aucune source EPG sélectionnée, rien à faire"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Appuyez sur OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Vraiment effacer toute la liste?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Retour à veille profonde après l'importation"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Exécutez AutoTimer après l'importation"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Samedi"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Sauvegarder"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Choisir une action"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Afficher \"EPG Importer\" dans le menu principal"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Afficher \"EPGImport\" dans le menu extension"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Afficher le log"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Eviter l'import au redémarrage GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Sources"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Démarrer en veille"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Charger import après le démarrage"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Dimanche"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Jeudi"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Mardi"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Mercredi"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Lorsqu'il est en veille profonde"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Écrire dans /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -228,6 +297,7 @@ msgstr ""
 "Vous ne pouvez pas utiliser ces paramètres!\n"
 "Au moins un jour par semaine devrait être inclus!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -235,20 +305,26 @@ msgstr ""
 "Vous devez redémarrer Enigma2 pour lire les données EPG,\n"
 "Êtes-vous d'accord ?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "toujours"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "jamais"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "seulement au démarrage auto."
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "seulement au démarrage manuel"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "passer l'import"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "réveiller et importer"

--- a/src/EPGImport/locale/it.po
+++ b/src/EPGImport/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2018-04-17 23:21+0200\n"
 "Last-Translator: Gringo <openpli@tiscali.it>\n"
 "Language-Team: \n"
@@ -21,6 +21,7 @@ msgstr ""
 "X-Poedit-Basepath: .\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -32,74 +33,97 @@ msgstr ""
 "Questa operazione potrebbe durare alcuni minuti.\n"
 "Proseguire?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " eventi\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Aggiungere un canale"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Aggiungere un provider"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Tutti i provider di canali"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Importazione automatica dell'EPG"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Importazione automatica dell'EPG"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Orario di inizio dell'importazione automatica"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Annullare"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Selezione del canale"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Selezionare i giorni nei quali importare"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Eliminare"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Eliminare l'EPG presente prima di importare"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Utilizzare le impostazioni \"Profilo giornaliero\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Profilo giornaliero"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Eliminare tutto"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Eliminare gli elementi selezionati"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Configurazione dell'importazione dell'EPG"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Registro dell'importazione dell'EPG"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Origini selezionabili per l'importazione dell'EPG"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Importazione EPG completata, %d eventi"
 
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "Importazione EPG"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPG Import"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -107,6 +131,7 @@ msgstr ""
 "Importazione EPG\n"
 "L'importazione dell'EPG è ancora in corso. Si prega di attendere."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -118,6 +143,7 @@ msgstr ""
 "Questa operazione potrebbe durare alcuni minuti.\n"
 "Proseguire?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -125,18 +151,30 @@ msgstr ""
 "Plugin EPGImport \n"
 "Errore di avvio:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Venerdì"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Ignorare la lista canali"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorare la lista canali (premere OK per salvare)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importare l'origine selezionata"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -145,92 +183,121 @@ msgstr ""
 "Importazione di: %s\n"
 "%s eventi"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Ultima importazione: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Ultima importazione: %s eventi"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Ultima: %s %s, %d eventi"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Caricare l'EPG solo per i canali inclusi nei bouquet"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Caricare le informazioni per un periodo di (giorni):"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manuale"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Lunedì"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Nessuna origine EPG selezionata, impossibile procedere"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Premere OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Si desidera veramente eliminare tutte le liste?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Spegnere il ricevitore dopo l'importazione"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Eseguire AutoTimer dopo l'importazione"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Sabato"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Salvare"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Scegliere un'operazione"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Mostrare \"Importazione EPG\" nel menu principale"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Mostrare \"Importazione EPG\" tra le estensioni"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Mostrare il registro"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Tralasciare l'importazione in caso di riavvio dell'interfaccia utente"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Origini"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "In sospensione all'avvio"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Avviare l'importazione all'accensione"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Domenica"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Giovedì"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Martedì"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Mercoledì"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "In stato di spegnimento"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Salvataggio su /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -238,6 +305,7 @@ msgstr ""
 "Non è possibile usare queste impostazioni!\n"
 "E' necessario includere almeno un giorno della settimana!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -245,20 +313,26 @@ msgstr ""
 "E' necessario riavviare Enigma2 per caricare i dati EPG.\n"
 "Procedere?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "Sempre"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "Mai"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "Solo in caso di accensione automatica del ricevitore"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "Solo in caso di accensione manuale del ricevitore"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "Tralasciare l'importazione"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "Riattivare il ricevitore ed importare"

--- a/src/EPGImport/locale/nb.po
+++ b/src/EPGImport/locale/nb.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2016-12-31 17:00+0100\n"
 "Last-Translator: andy1 <dummy@dummy.com>\n"
 "Language-Team: G.Jensen\n"
@@ -14,6 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,22,-1,-1,-1,-1\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -25,74 +26,97 @@ msgstr ""
 "Dette kan ta noen minutter.\n"
 "Er det ok?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr "program\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Legg til kanal"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Legg til distributør"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Alle distributør kanaler"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automatisk EPG import"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Automatisk EPG import"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Automatisk start tid"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Annuller"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Kanal valg"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Velg dager for import"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Slett"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Slett nåværende EPG før import"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Vurder oppsett av  \"Dagsprofiler\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Dagsprofiler"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Slett alle"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Slett valgte"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "EPG import innstilling"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG import logg"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "EPG import kilder"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG Import er ferdig, %d program"
 
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "EPG importerer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPG import"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -100,6 +124,7 @@ msgstr ""
 "EPG import\n"
 "Import av EPG data er på gang. Vennligst vent."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -111,6 +136,7 @@ msgstr ""
 "Dette vil ta noen minutter.\n"
 "Er det ok?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -118,18 +144,30 @@ msgstr ""
 "EPG import tillegget\n"
 "Feilet ved oppstart:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Fredag"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Ignorer kanallistene"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorer kanallistene (tast OK og lagre)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importer nåværende kilde"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -138,92 +176,121 @@ msgstr ""
 "Importerer:%s\n"
 "%s program"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Siste import:"
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Siste import: %s program"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Siste: %s %s, %d program"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Last bare inn EPG program i kanallistene"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Last hele beskrivelser opp til X dager"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manuell"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Mandag"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Ingen aktiv EPG kilde ble funnet, ikke noe kan gjøres"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Tast OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Slett alle listene?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Gå til 'helt avslått' etter import"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Kjør AutoTidtaker etter import"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Lørdag"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Lagre"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Velg handling"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Vis \"EPG import\" i hovedmeny"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Vis \"EPG import\" i tilleggsmeny"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Vis logg"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Ikke importer ved restart av GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Kilder"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Slå av etter oppstart"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Start import etter oppstart"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Søndag"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Torsdag"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Tirsdag"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Onsdag"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Når i helt avslått"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Skriv til /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -231,6 +298,7 @@ msgstr ""
 "Innstillingen må ikke nødvendigvis brukes!\n"
 "Minst en dag i uken bør inkluderes!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -238,20 +306,26 @@ msgstr ""
 "Enigma2 må startes på nytt for å laste inn EPG data,\n"
 "er dette OK?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "alltid"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "aldri"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "bare automatisk oppstart"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "bare manuell oppstart"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "hopp over import"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "slå på og importer"

--- a/src/EPGImport/locale/nl.po
+++ b/src/EPGImport/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2018-01-08 21:58+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,6 +20,7 @@ msgstr ""
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-SearchPath-0: .\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -31,73 +32,96 @@ msgstr ""
 "Dit kan een paar minuten duren\n"
 "Wilt u doorgaan?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " programma's\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Zender toevoegen"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Provider toevoegen"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Alle zender providers"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automatisch EPG importeren"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Automatisch EPG importeren"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Automatische start tijd"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Annuleer"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Zender keuze"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Selecteer dagen voor importeren"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Wis"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Wis huidige EPG voor importeren"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Overweeg een \"dagen profiel\" te gebruiken"
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Dagenprofiel"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Verwijder alles"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Geselecteerde verwijderen"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "EPG-Import configuratie"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG-Import log"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "EPG-Import bronnen"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG importeren gereed, %d programma's"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "EPG-importer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPG-Import"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -105,6 +129,7 @@ msgstr ""
 "EPG-Import\n"
 "Importeren van epg-data is nog bezig. Even geduld."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -116,6 +141,7 @@ msgstr ""
 "Dit kan een enkele minuten duren.\n"
 "Doorgaan?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -123,18 +149,30 @@ msgstr ""
 "EPG-Import Plugin\n"
 "Starten mislukt:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Vrijdag"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Negeer zenderlijst"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Negeer zenderlijst ( druk OK voor opslaan)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importeer bron"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -143,92 +181,121 @@ msgstr ""
 "Importeert: %s\n"
 "%s programma's"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Laatste import: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Laatste import: %s programma's"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Laatste: %s %s, %d programma's"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Laad enkel EPG van zenders in bouquetten"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Laad uitgebreide beschrijvingen tot-en-met X dagen"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Handmatig"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Maandag"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Geen actieve EPG bronnen gevonden, kan niets doen"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Druk op OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Werkelijk alle lijsten wissen?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Weer uitschakelen na de importeren"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Activeer AutoTimer na importeren"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Zaterdag"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Opslaan"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Selecteer actie"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Toon \"EPG importer\" in hoofdmenu"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Toon \"EPG importer\" in extensions"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Toon log"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Importeren overslaan na herstart GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Bronnen"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Stand-by na opstarten"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Start importeren na opstarten"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Zondag"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Donderdag"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Dinsdag"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Woensdag"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Wanneer ontvanger is uitgeschakeld"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Schrijf naar /tmp/EPGimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -236,6 +303,7 @@ msgstr ""
 "U kunt deze instellingen niet gebruiken!\n"
 "Er moet tenminste één dag per week worden ingesteld!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -243,20 +311,26 @@ msgstr ""
 "U moet nu Enigma2 herstarten om de EPG-data te laden,\n"
 "Wilt u doorgaan?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "atijd"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "nooit"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "enkel na automatische herstart"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "enkel na handmatige herstart"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "importeren overslaan"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "ontwaak en importeer"

--- a/src/EPGImport/locale/pl.po
+++ b/src/EPGImport/locale/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2014-04-24 19:01+0100\n"
 "Last-Translator: Mariusz1970 <Mariusz1970@onet.eu>\n"
 "Language-Team: none <Mariusz1970@onet.eu>\n"
@@ -14,6 +14,7 @@ msgstr ""
 "X-Generator: Poedit 1.6.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
+#: ../plugin.py:703
 #, fuzzy
 msgid ""
 "\n"
@@ -26,76 +27,99 @@ msgstr ""
 "Może to potrwać kilka minut\n"
 "jest ok?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr ""
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr ""
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr ""
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr ""
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automatyczny EPG Importer"
 
+#: ../plugin.py:336
 #, fuzzy
 msgid "Automatic import EPG"
 msgstr "Codzienny automatyczny import"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Automatyczny czas rozpoczęcia"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Anuluj"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr ""
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr ""
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Czyść"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr ""
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr ""
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr ""
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr ""
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Konfiguracja EPG Importu"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Import EPG Logi"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Import EPG Źródła"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Import EPG zakończony, %d wydarzenia"
 
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
+#: ../plugin.py:451
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -104,6 +128,7 @@ msgstr ""
 "Import EPG Plugin\n"
 "Import danych EPG jest nadal w toku. Proszę czekać."
 
+#: ../plugin.py:467
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -116,6 +141,7 @@ msgstr ""
 "Może to potrwać kilka minut\n"
 "jest ok?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -123,117 +149,159 @@ msgstr ""
 "Import EPG Plugin\n"
 "Nie powiodło się:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr ""
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr ""
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
+#: ../plugin.py:547
 #, fuzzy
 msgid "Import current source"
 msgstr "Import EPG Źródła"
 
+#: ../plugin.py:300
 #, fuzzy, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr "Import EPG zakończony, %d wydarzenia"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr ""
 
+#: ../plugin.py:446
 #, fuzzy, python-format
 msgid "Last import: %s events"
 msgstr "Ostatnie: %s %s, %d wydarzenia"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Ostatnie: %s %s, %d wydarzenia"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Załadować długie opisy do X dni"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manualnie"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr ""
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Nie odnaleziono aktywnych źródeł EPG, nic nie można zrobić"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr ""
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr ""
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr ""
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr ""
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr ""
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Zapisz"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr ""
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr ""
 
+#: ../plugin.py:346
 #, fuzzy
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Pokaż w rozszerzeniach"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr ""
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr ""
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Źródła"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Czuwania przy starcie"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Zacznij import po uruchomieniu systemu"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr ""
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr ""
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr ""
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr ""
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Gdy w głębokim trybie gotowości"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -241,23 +309,29 @@ msgstr ""
 "Należy ponownie uruchomić enigmę aby załadować dane EPG,\n"
 "jest OK?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr ""
 
+#: ../plugin.py:54
 msgid "never"
 msgstr ""
 
+#: ../plugin.py:53
 #, fuzzy
 msgid "only automatic boot"
 msgstr "Codzienny automatyczny import"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr ""
 
+#: ../plugin.py:62
 #, fuzzy
 msgid "skip the import"
 msgstr "Przejdź na import"
 
+#: ../plugin.py:61
 #, fuzzy
 msgid "wake up and import"
 msgstr "Budzenie i import"

--- a/src/EPGImport/locale/pt.po
+++ b/src/EPGImport/locale/pt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EpgImporter for enigma2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2017-08-28 18:35+0100\n"
 "Last-Translator: \n"
 "Language-Team: BH-Team\n"
@@ -14,6 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -25,74 +26,97 @@ msgstr ""
 "Isto pode levar alguns minutos.\n"
 "Confirma?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " eventos\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Adicionar Canal"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Adicionar Operador"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Todos os Operadores de Serviços"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Importador EPG automatizado"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Importação automática de EPG"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Hora de início automático"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Cancelar"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Seleção de Canais"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Escolha de dias para começar a importação"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Limpar"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Limpar o EPG atual antes de importar"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Considere a configuração de \"Perfil de dias\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Perfil de dias"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Eliminar tudo"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Eliminar selecionados"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Configuração de importação EPG"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Log de importação EPG"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Fontes de importação do EPG"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG importação concluída, %d eventos"
 
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "Importador EPG"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPGImport"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -100,6 +124,7 @@ msgstr ""
 "EPGImport\n"
 "Importação de dados epg ainda está em andamento. Aguarde."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -111,6 +136,7 @@ msgstr ""
 "Isto pode levar alguns minutos.\n"
 "Confirma?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -118,18 +144,30 @@ msgstr ""
 "EPGImport Plugin\n"
 "Falha ao iniciar:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Sexta feira"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Ignorar a lista de serviços"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorar a lista de serviços (Premir OK para salvar)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importar a fonte atual"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -138,92 +176,121 @@ msgstr ""
 "Importação: %s\n"
 "%s eventos"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Última importação: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Última importação: %s eventos"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Última: %s %s, %d eventos"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Carregar EPG sómente em bouquets"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Carregar descrições longas de até X dias"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manual"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Segunda-feira"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Sem fontes EPG ativas encontradas, nada a fazer"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Prima OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Apagar realmente todas as listas?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Desligar a STB após a importação"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Executar AutoTimer após a importação"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Sábado"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Guardar"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Selecionar ação"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Mostrar \"Importador de EPG\" no menu principal"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Mostrar \"EPGImport\" em extensões"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Mostrar registo"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Ignorar a importação na reinicialização do GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Fontes"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Espera na inicialização"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Iniciar importação depois do arranque"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Domingo"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Quinta-Feira"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Terça-Feira"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Quarta-Feira"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Quando em Modo de espera"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Gravar em /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -231,6 +298,7 @@ msgstr ""
 "Não deve usar estas configurações!\n"
 "Pelo menos um dia que por semana deve ser incluída!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -238,20 +306,26 @@ msgstr ""
 "Deve reiniciar Enigma2 para carregar os dados EPG,\n"
 "Confirma?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "sempre"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "nunca"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "só arranque automático"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "só arranque manual"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "ignorar a importação"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "acordar e importar"

--- a/src/EPGImport/locale/ru.po
+++ b/src/EPGImport/locale/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2016-05-27 22:10+0300\n"
 "Last-Translator: Dimitrij <Dima-73@inbox.lv>\n"
 "Language-Team: LANGUAGE <Dima-73@inbox.lv>\n"
@@ -12,6 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.4\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -23,73 +24,96 @@ msgstr ""
 "Это может занять несколько минут.\n"
 "Это вас устраивает?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " событий\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Добавить канал"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Добавить провайдера"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Все сервисы провайдера"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Автоматический импортер EPG"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Автоматический импорт EPG"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Начало автоматического старта"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Отмена"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Выбор каналов"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Выбор дней для старта импорта"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Очистка"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Очистка текущего EPG перед импортом"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Учесть настройки \"Профиль дней\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Профиль дней"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Удалить все"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Удалить выбранное"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "EPG импорт - настройки"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG импорт - лог"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Источники импорта EPG"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG импорт закончен, %d событий"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "Импортер EPG"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPG импорт"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -97,6 +121,7 @@ msgstr ""
 "EPG импорт\n"
 "Импорт данных EPG все еще продолжается. Пожалуйста подождите."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -108,6 +133,7 @@ msgstr ""
 "Это может занять несколько минут.\n"
 "Это вас устраивает?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -115,18 +141,30 @@ msgstr ""
 "EPG импорт\n"
 "Ошибка старта:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Пятница"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Список игногируемых сервисов"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Список игногируемых сервисов (ОК для сохранения)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Импорт текущего источника"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -135,92 +173,121 @@ msgstr ""
 "Импортируем: %s\n"
 "%s событий"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Последний импорт: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Последний импорт: %s событий"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Последний импорт: %s %s, %d событий"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Загрузка EPG только для сервисов из букетов"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Загрузка длинных описаний не больше чем на Х дней"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "В ручную"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Понедельник"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Нет найденных активных источников EPG."
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Нажмите ОК"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Удалить весь список?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Возврат в режим глубокого ожидания после импорта"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Запустить Автотаймер по окончании импорта"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Суббота"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Сохранить"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Выбор действия"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Показать \"Импортер EPG\" в главном меню"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Показать \"EPG импорт\" в меню дополнений"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Показать лог"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Пропускать импорт после рестарта GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Источники"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Перейти в режим ожидания после загрузки"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Старт импорта после загрузки"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Воскресенье"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Четверг"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Вторник"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Среда"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Поведение в глубоком ожидании"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Запись в /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -228,6 +295,7 @@ msgstr ""
 "Вы не можете использовать эти настройки!\n"
 "По крайней мере один день недели должен быть активирован!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -235,20 +303,26 @@ msgstr ""
 "Необходим рестарт Энигма2 для загрузки данных EPG,\n"
 "сделать это сейчас?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "всегда"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "никогда"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "только при авто загрузке"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "только при ручной загрузке"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "пропускать импорт"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "разбудить для импорта"

--- a/src/EPGImport/locale/sv.po
+++ b/src/EPGImport/locale/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2016-12-31 17:00+0100\n"
 "Last-Translator: Jonas Bohdén <jonas@bohden.se>\n"
 "Language-Team: Jonas Bohdén\n"
@@ -14,6 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,22,-1,-1,-1,-1\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -25,74 +26,97 @@ msgstr ""
 "Detta kan ta några minuter.\n"
 "Är detta okej?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr "program\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Lägg till kanal"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Lägg till leverantör"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Alla kanalleverantörer"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Automatisk EPG-importerare"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Automatisk EPG-importering"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Automatisk starttid"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Avbryt"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Kanalväljare"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Välj dagar att starta importering"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Rensa"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Rensar nuvarande EPG före importering"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Överväg inställning av \"Dagarprofil\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Dagarprofil"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Radera alla"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Radera valda"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "Konfiguration för EPG-importering"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "Logg för EPG-importering"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Källor för EPG-importering"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG-importering klar, %d program"
 
+#: ../plugin.py:721
 #, fuzzy
 msgid "EPG Importer"
 msgstr "EPG-importerare"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPGImport"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -100,6 +124,7 @@ msgstr ""
 "EPGImport\n"
 "Importering av EPG-data pågår fortfarande. Vänligen vänta..."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -111,6 +136,7 @@ msgstr ""
 "Detta kan ta några minuter.\n"
 "Är detta okej?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -118,18 +144,30 @@ msgstr ""
 "EPGImport Plugin\n"
 "Misslyckades att starta:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "Fredag"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Ignorera kanallistor"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorera kanallistor (tryck på OK för att spara)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Importera nuvarande källa"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -138,92 +176,121 @@ msgstr ""
 "Importerar: %s\n"
 "%s program"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Senaste importering: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Senaste importering: %s program"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Senast: %s %s, %d program"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Ladda endast EPG för kanaler i kanallistorna"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Ladda långa beskrivningar i upp till X dagar"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "Manuellt"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Måndag"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Ingen aktiv EPG-källa hittades, inget att göra"
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Tryck OK"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Radera alla listor?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Återgå till djup standby efter importering"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Kör AutoTimer efter importering"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Lördag"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Spara"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Välj åtgärd"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Visa \"EPG-importerare\" i huvudmenyn"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Visa \"EPG-importerare\" i utökningar"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Visa logg"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Hoppa över importering vid omstart av GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Källor"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Standby vid uppstart"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Starta importering efter uppstart"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Söndag"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Torsdag"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Tisdag"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Onsdag"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Vid djup standby"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Skriv till /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -231,6 +298,7 @@ msgstr ""
 "Du får inte använda dessa inställningar!\n"
 "Minst en dag i veckan ska inkluderes!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -238,20 +306,26 @@ msgstr ""
 "Du måste starta om Enigma2 för att ladda EPG-datan,\n"
 "Är detta okej?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "alltid"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "aldrig"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "endast automatisk uppstart"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "endast manuell uppstart"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "hoppa över importeringen"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "väck upp och importera"

--- a/src/EPGImport/locale/uk.po
+++ b/src/EPGImport/locale/uk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: enigma2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:33+0200\n"
+"POT-Creation-Date: 2019-01-01 00:42+0100\n"
 "PO-Revision-Date: 2016-07-12 17:21+0200\n"
 "Last-Translator: satdreamgr\n"
 "Language-Team: sety <tim1065@mail.ru>\n"
@@ -13,6 +13,7 @@ msgstr ""
 "X-Generator: Poedit 1.8.8\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
+#: ../plugin.py:703
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,73 +25,96 @@ msgstr ""
 "Це може зайняти кілька хвилин.\n"
 "Це вас влаштовує?"
 
+#: ../plugin.py:703
 msgid " events\n"
 msgstr " подій\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "Додати канал"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "Додати провайдера"
 
+#: ../filtersServices.py:247
 msgid "All services provider"
 msgstr "Все сервіси провайдера"
 
+#: ../plugin.py:1044
 msgid "Automated EPG Importer"
 msgstr "Автоматичний імпортер EPG"
 
+#: ../plugin.py:336
 msgid "Automatic import EPG"
 msgstr "Автоматичний імпорт EPG"
 
+#: ../plugin.py:337
 msgid "Automatic start time"
 msgstr "Початок автоматичного старту"
 
+#: ../plugin.py:278 ../plugin.py:524 ../plugin.py:603
 msgid "Cancel"
 msgstr "Скасування"
 
+#: ../filtersServices.py:239
 msgid "Channel Selection"
 msgstr "Вибір каналів"
 
+#: ../plugin.py:341
 msgid "Choice days for start import"
 msgstr "Вибір днів для старту імпорту"
 
+#: ../plugin.py:657
 msgid "Clear"
 msgstr "Очищення"
 
+#: ../plugin.py:350
 msgid "Clearing current EPG before import"
 msgstr "Очищення поточного EPG перед імпортом"
 
+#: ../plugin.py:344
 msgid "Consider setting \"Days Profile\""
 msgstr "Врахувати настройки \"Профіль днів\""
 
+#: ../plugin.py:616
 msgid "Days Profile"
 msgstr "Профіль днів"
 
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "Удалить все"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "Видалити вибране"
 
+#: ../plugin.py:274
 msgid "EPG Import Configuration"
 msgstr "EPG імпорт - налаштування"
 
+#: ../plugin.py:681
 msgid "EPG Import Log"
 msgstr "EPG імпорт - лог"
 
+#: ../plugin.py:559
 msgid "EPG Import Sources"
 msgstr "Джерело імпорту EPG"
 
+#: ../plugin.py:749
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG импорт закінчено, %d подій"
 
+#: ../plugin.py:721
 msgid "EPG Importer"
 msgstr "Імпортер EPG"
 
+#: ../plugin.py:1046 ../plugin.py:1061
 msgid "EPGImport"
 msgstr "EPG імпорт"
 
+#: ../plugin.py:451
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -98,6 +122,7 @@ msgstr ""
 "EPG імпорт\n"
 "Імпорт даних EPG все ще триває. Зачекайте, будь ласка."
 
+#: ../plugin.py:467
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -109,6 +134,7 @@ msgstr ""
 "Це може зайняти кілька хвилин.\n"
 "Це вас влаштовує?"
 
+#: ../plugin.py:476
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -116,18 +142,30 @@ msgstr ""
 "EPG імпорт\n"
 "Помилка старта:\n"
 
+#: ../plugin.py:299
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Friday"
 msgstr "П'ятниця"
 
+#: ../plugin.py:489
 msgid "Ignore services list"
 msgstr "Список ігнорованих сервісів"
 
+#: ../filtersServices.py:153
 msgid "Ignore services list(press OK to save)"
 msgstr "Список ігнорованих сервісів (ОК для збереження)"
 
+#: ../plugin.py:547
 msgid "Import current source"
 msgstr "Імпорт поточного джерела"
 
+#: ../plugin.py:300
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -136,92 +174,121 @@ msgstr ""
 "Імпортуємо: %s\n"
 "%s подій"
 
+#: ../plugin.py:703
 msgid "Last import: "
 msgstr "Останній імпорт: "
 
+#: ../plugin.py:446
 #, python-format
 msgid "Last import: %s events"
 msgstr "Останній імпорт: %s подій"
 
+#: ../plugin.py:441
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Останній імпорт: %s %s, %d подій"
 
+#: ../plugin.py:343
 msgid "Load EPG only services in bouquets"
 msgstr "Завантаження EPG тільки для сервісів з букетів"
 
+#: ../plugin.py:348
 msgid "Load long descriptions up to X days"
 msgstr "Завантаження довгих описів не більше ніж на Х днів"
 
+#: ../plugin.py:280
 msgid "Manual"
 msgstr "В ручну"
 
+#: ../plugin.py:80
 msgid "Monday"
 msgstr "Понеділок"
 
+#: ../plugin.py:462
 msgid "No active EPG sources found, nothing to do"
 msgstr "Не знайдено активних джерел EPG."
 
+#: ../plugin.py:72
 msgid "Press OK"
 msgstr "Натисніть ОК"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "Видалити весь список?"
 
+#: ../plugin.py:339
 msgid "Return to deep standby after import"
 msgstr "Повернення в режим глибокого очікування після імпорту"
 
+#: ../plugin.py:349
 msgid "Run AutoTimer after import"
 msgstr "Запустити Автотаймер після закінчення імпорту"
 
+#: ../plugin.py:85
 msgid "Saturday"
 msgstr "Субота"
 
+#: ../plugin.py:279 ../plugin.py:525 ../plugin.py:604 ../plugin.py:660
 msgid "Save"
 msgstr "Зберегти"
 
+#: ../filtersServices.py:265 ../plugin.py:490
 msgid "Select action"
 msgstr "Вибір дії"
 
+#: ../plugin.py:347
 msgid "Show \"EPG Importer\" in main menu"
 msgstr "Показувати \"EPG імпортер\"в головному меню"
 
+#: ../plugin.py:346
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Показувати \"EPG імпорт\" в меню доповнень"
 
+#: ../plugin.py:489
 msgid "Show log"
 msgstr "Показувати лог"
 
+#: ../plugin.py:345
 msgid "Skip import on restart GUI"
 msgstr "Пропускати імпорт після рестарту GUI"
 
+#: ../plugin.py:281
 msgid "Sources"
 msgstr "Джерела"
 
+#: ../plugin.py:340
 msgid "Standby at startup"
 msgstr "Перейти в режим очікування після завантаження"
 
+#: ../plugin.py:342
 msgid "Start import after booting up"
 msgstr "Старт імпорту після завантаження"
 
+#: ../plugin.py:86
 msgid "Sunday"
 msgstr "Неділя"
 
+#: ../plugin.py:83
 msgid "Thursday"
 msgstr "Четвер"
 
+#: ../plugin.py:81
 msgid "Tuesday"
 msgstr "Вівторок"
 
+#: ../plugin.py:82
 msgid "Wednesday"
 msgstr "Середа"
 
+#: ../plugin.py:338
 msgid "When in deep standby"
 msgstr "Поведінка в глибокому очікуванні"
 
+#: ../plugin.py:687
 msgid "Write to /tmp/epgimport.log"
 msgstr "Запис в /tmp/epgimport.log"
 
+#: ../plugin.py:626
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -229,6 +296,7 @@ msgstr ""
 "Ви не можете використовувати ці настройки!\n"
 "Принаймні один день тижня має бути активований!"
 
+#: ../plugin.py:749
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -236,20 +304,26 @@ msgstr ""
 "Необхідний рестарт Енігма2 для завантаження даних EPG,\n"
 "Зробити це зараз?"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "завжди"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "ніколи"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "тільки при автозавантаженні"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "тільки при ручному завантаженні"
 
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "Пропускати імпорт"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "розбудити для імпорту"


### PR DESCRIPTION
When the option to only load EPG for favourites is enabled, this process takes a very long time to create the filter, and no progression was display. 
So people can think that EPGImport was stuck or in an endless loop.
Now a progression counter is displayed.
Since a new string is added, pot and po files are also included in this PR.