### PR TITLE
Allow exact positioning of the expandable icon and category description

### DIFF
--- a/src/EPGImport/ExpandableSelectionList.py
+++ b/src/EPGImport/ExpandableSelectionList.py
@@ -52,7 +52,6 @@ def entry(description, value, selected):
 def expand(cat, value=True):
 	# cat is a list of data and icons
 	if cat[0][1] != value:
-		ix, iy, iw, ih = skin.parameters.get("SelectionListLock", (0, 2, 25, 24))
 		if value:
 			icon = expandedIcon
 		else:

--- a/src/EPGImport/ExpandableSelectionList.py
+++ b/src/EPGImport/ExpandableSelectionList.py
@@ -9,13 +9,20 @@ expandedIcon = LoadPixmap(resolveFilename(SCOPE_CURRENT_SKIN, "icons/expanded.pn
 
 def loadSettings():
 	global cat_desc_loc, entry_desc_loc, cat_icon_loc, entry_icon_loc
-	x, y, w, h = skin.parameters.get("SelectionListDescr", (25, 3, 650, 30))
-	ind = x # Indent the entries by the same amount as the icon.
+
+	# expandable list (skin parameters defined by the plugin)
+	x, y, w, h = skin.parameters.get("ExpandableListDescr", (40, 3, 650, 30))
 	cat_desc_loc = (x, y, w, h)
-	entry_desc_loc = (x + ind, y, w - ind, h)
+	x, y, w, h = skin.parameters.get("ExpandableListIcon", (0, 2, 30, 25))
+	cat_icon_loc = (x, y, w, h)
+
+	indent = x + w # indentation for the selection list entries
+
+	# selection list (skin parameters also used in enigma2)
+	x, y, w, h = skin.parameters.get("SelectionListDescr", (25, 3, 650, 30))
+	entry_desc_loc = (x + indent, y, w - indent, h)
 	x, y, w, h = skin.parameters.get("SelectionListLock", (0, 2, 25, 24))
-	cat_icon_loc = (x, 0, w, y + y + h) # The category icon is larger
-	entry_icon_loc = (x + ind, y, w, h)
+	entry_icon_loc = (x + indent, y, w, h)
 
 def category(description, isExpanded=False):
 	global cat_desc_loc, cat_icon_loc


### PR DESCRIPTION
Before this change, there was no way to exactly position the expanded/expandable icons  and the category description in the list, so the placement was done roughly by the plugin's code. The PLi skins didn't like that very much... See picture below.

By adding two new parameters in the code, skinners can now choose the exact position of their icons. Please make sure you also commit the PR in the PLi skin: https://github.com/littlesat/skin-PLiHD/pull/808

See old vs new comparison below.

![epg_import](https://user-images.githubusercontent.com/1540233/67947655-ca83ce00-fbec-11e9-9ec4-d0f4536a8ad5.png)

