### PR TITLE
Add support for "channel id" filtering during import

### DIFF
--- a/etc/epgimport/channel_id_filter.conf
+++ b/etc/epgimport/channel_id_filter.conf
@@ -1,0 +1,18 @@
+# . means any characters
+# * means 0 or more characters
+# + means 1 or more characters
+# \. means the dot itself (since . means any characters)
+# ^ start of the string
+# $ means end of the string
+#
+# The filters are turned into lower case because the channel id are also always turned into lower case in EPGImport
+# So FR, Fr, fR will anyway be turned into: fr
+#
+# So if you want to exclude every french channel id use
+# .*\.fr
+# This means any string ending by .fr will be filtered out
+#
+# And OR operation is performed between every line
+#
+# You can also specify the single channel id example:    DiscoveryHD\.dk   will only match the channel id="DiscoveryHD.dk"
+#

--- a/etc/epgimport/readme.txt
+++ b/etc/epgimport/readme.txt
@@ -15,3 +15,54 @@ Special thanks go to:
 The PLi team for putting up with me
 All the sat4all.com folks who contributed
 
+Request:
+
+Some channels share the same service reference but have multiple languages available for there EPG.
+Today it is always the latest loaded EPG data file that will push its language and you have no easy control on this download order.
+The current solution is to totally exclude the downloading of an EPG package file but this not always possible (for exemple news channels are all in the same file).
+
+<!-- DK --> <!-- 0.8W --> <channel id=" DiscoveryHD.dk "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
+<!-- FI --> <!-- 0.8W --> <channel id=" DiscoveryHD.fi "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
+<!-- HRV --> <!-- 0.8W --> <channel id=" DiscoveryHDShowcase.rs "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
+<!-- HU --> <!-- 0.8W --> <channel id=" DiscoveryHDShowcase.hu "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
+<!-- NO --> <!-- 0.8W --> <channel id=" DiscoveryChannel.no "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
+<!-- SE --> <!-- 0.8W --> <channel id=" DiscoveryHDshowcase.se "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
+<!-- SVN --> <!-- 0.8W --> <channel id=" DiscoveryHD.svn "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  HD Discovery Shovcase  -->
+
+All the same service ref, but different language EPG attached.
+
+It was requested to find a mechanism to filter out some specific or group of channel id.
+
+
+Solution:
+
+You can now create a file /etc/epgimport/channel_id_filter.conf
+
+this file will containt one regular expression per line, a logical OR operation will be performed between every regular expression (regex) lines.
+There are many tutorials about regex on the internet. But here is some basis for you:
+
+. means any characters but only once
+* means 0 or more characters
++ means 1 or more characters
+\. means the dot itself (since . means any characters)
+^ start of the string
+$ means end of the string
+.* will replace any characters
+
+The filters are turned into lower case because the channel id are also always turned into lower case in EPGImport
+So FR, Fr, fR will anyway be turned into: fr
+
+So if you want to exclude every french channel id use
+.*\.fr
+This means any string ending by .fr will be filtered out
+
+Remark:  
+-> *\.fr is not a valid regex because * means that the preceding char should repeated several times but you don't specify any, so .* is the correct syntax. Remember . means any char but . only means only one time any char.
+-> Invalid regex will simply be ignored (it will be mentionned in the EPGImport log) but this won't prevent the EPG loading.
+-> Too wide regex will filter out more than you expect, for example if you define just .* you will have no EPG because everything will be filtered out. So use wildcard with caution. If you are not familiar with regex use the fixed syntax: ChannelIDName\.Extension
+
+
+You can also specify the single channel id example:    discoveryhd\.dk   will only match the channel id="DiscoveryHD.dk" (remember the channel id is turned into lowercase).
+If you decide to exclude all the .dk channel id you can simply specify:  .*\.dk
+
+The filter will apply to every possible channels.xml files so once you define an exclusion it will be use globally. You can only control the filtering on the /etc/epgimport/custom_channels.xml file.

--- a/src/EPGImport/EPGConfig.py
+++ b/src/EPGImport/EPGConfig.py
@@ -5,11 +5,13 @@ import cPickle as pickle
 import gzip
 import time
 import random
+import re
 
 # User selection stored here, so it goes into a user settings backup
 SETTINGS_FILE = '/etc/enigma2/epgimport.conf'
 
 channelCache = {}
+global filterCustomChannel
 
 def isLocalFile(filename):
 	# we check on a '://' as a silly way to check local file
@@ -35,6 +37,47 @@ def getChannels(path, name):
 	channelCache[channelfile] = c
 	return c
 
+def set_channel_id_filter():
+	full_filter=""
+	try:
+		with open('/etc/epgimport/channel_id_filter.conf', 'r') as channel_id_file:
+			for channel_id_line in channel_id_file:
+				# Skipping comments in channel_id_filter.conf
+				if not channel_id_line.startswith("#"):
+					clean_channel_id_line=channel_id_line.strip()
+					# Blank line in channel_id_filter.conf will produce a full match so we need to skip them.
+					if clean_channel_id_line:
+						try:
+							# We compile indivually every line just to report error
+							re_test=re.compile(clean_channel_id_line)
+						except re.error:
+							print>>log, "[EPGImport] ERROR: "+clean_channel_id_line+" is not a valid regex. It will be ignored."
+						else:	
+							full_filter=full_filter+clean_channel_id_line+"|"
+	except IOError:
+		print>>log, "[EPGImport] INFO: no channel_id_filter.conf file found."
+		# Return a dummy filter (empty line filter) all accepted except empty channel id
+		compiled_filter=re.compile("^$")
+		return(compiled_filter)
+	# Last char is | so remove it	
+	full_filter=full_filter[:-1]
+	# all channel id are matched in lower case so creating the filter in lowercase too
+	full_filter=full_filter.lower()
+	# channel_id_filter.conf file exist but is empty, it has only comments, or only invalid regex
+	if len(full_filter) == 0 :
+		# full_filter is empty returning dummy filter
+		compiled_filter=re.compile("^$")
+	else:
+		try:
+			compiled_filter=re.compile(full_filter)
+		except re.error:
+			print>>log, "[EPGImport] ERROR: final regex "+full_filter+" doesn't compile properly."
+			# Return a dummy filter  (empty line filter) all accepted except empty channel id
+			compiled_filter=re.compile("^$")
+		else:
+			print>>log, "[EPGImport] INFO : final regex "+full_filter+" compiled successfully."
+	
+	return(compiled_filter)
 
 class EPGChannel:
 	def __init__(self, filename, urls=None):
@@ -58,8 +101,9 @@ class EPGChannel:
 				from backports import lzma
 			fd = lzma.open(filename, 'rb')
 		return fd
-	def parse(self, filterCallback, downloadedFile):
+	def parse(self, filterCallback, downloadedFile, FilterChannelEnabled):
 		print>>log,"[EPGImport] Parsing channels from '%s'" % self.name
+		channel_id_filter=set_channel_id_filter()
 		if self.items is None:
 			self.items = {}
 		try:
@@ -68,14 +112,33 @@ class EPGChannel:
 				if elem.tag == 'channel':
 					id = elem.get('id')
 					id = id.lower()
-					ref = elem.text
-					if id and ref:
-						ref = ref.encode('latin-1')
-						if filterCallback(ref):
-							if self.items.has_key(id):
-								self.items[id].append(ref)
-							else:
-								self.items[id] = [ref]
+					filter_result=channel_id_filter.match(id)
+					if filter_result and FilterChannelEnabled:
+						print>>log, "[EPGImport] INFO : skipping", filter_result.group(),"due to channel_id_filter.conf"
+						ref = elem.text
+						if id and ref:
+							ref = ref.encode('latin-1')
+							if filterCallback(ref):
+								if self.items.has_key(id):
+									try:
+										if ref in self.items[id] :
+											# remove only remove the first occurrence turning list into dict will make the reference unique so remove will work as expected.
+											self.items[id] = list(dict.fromkeys(self.items[id]))
+											self.items[id].remove(ref)
+									except Exception as e:
+										print>>log, "[EPGImport] failed to remove from list ", self.items[id], " ref ", ref, "Error:", e
+					else:
+						print>>log, "[EPGImport] INFO : processing", id
+						ref = elem.text
+						if id and ref:
+							ref = ref.encode('latin-1')
+							if filterCallback(ref):
+								if self.items.has_key(id):
+									self.items[id].append(ref)
+									# turning list into dict will make the reference unique to avoid loading twice the same EPG data.
+									self.items[id] = list(dict.fromkeys(self.items[id]))
+								else:
+									self.items[id] = [ref]
 					elem.clear()
 		except Exception as e:
 			print>>log, "[EPGImport] failed to parse", downloadedFile, "Error:", e
@@ -86,14 +149,14 @@ class EPGChannel:
 		# and we don't have multiple download from server problem since it is always a local file.
 		if os.path.exists(customFile):
 			print>>log,"[EPGImport] Parsing channels from '%s'" % customFile
-			self.parse(filterCallback, customFile)
+			self.parse(filterCallback, customFile, filterCustomChannel)
 		if downloadedFile is not None:
 			self.mtime = time.time()
-			return self.parse(filterCallback, downloadedFile)
+			return self.parse(filterCallback, downloadedFile, True)
 		elif (len(self.urls) == 1) and isLocalFile(self.urls[0]):
 			mtime = os.path.getmtime(self.urls[0])
 			if (not self.mtime) or (self.mtime < mtime):
-				self.parse(filterCallback, self.urls[0])
+				self.parse(filterCallback, self.urls[0], True)
 				self.mtime = mtime
 	def downloadables(self):
 		if (len(self.urls) == 1) and isLocalFile(self.urls[0]):
@@ -124,7 +187,7 @@ class EPGSource:
 		if not self.description:
 			self.description = self.url
 		self.format = elem.get('format', 'xml')
-		self.channels = getChannels(path, elem.get('channels'))
+		self.channels = getChannels(path, elem.get('channels'))	
 
 def enumSourcesFile(sourcefile, filter=None, categories=False):
 	global channelCache

--- a/src/EPGImport/locale/EPGImport.pot
+++ b/src/EPGImport/locale/EPGImport.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-23 18:07+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -25,7 +25,7 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr ""
 
@@ -41,19 +41,23 @@ msgstr ""
 msgid "All services provider"
 msgstr ""
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr ""
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr ""
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr ""
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr ""
 
@@ -61,24 +65,32 @@ msgstr ""
 msgid "Channel Selection"
 msgstr ""
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr ""
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr ""
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr ""
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
+msgstr ""
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
 msgstr ""
 
 #: ../filtersServices.py:216
@@ -89,38 +101,46 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr ""
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr ""
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr ""
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr ""
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 msgid "EPG import now"
 msgstr ""
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr ""
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
 msgstr ""
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -128,24 +148,24 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
 msgstr ""
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr ""
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr ""
 
@@ -153,52 +173,52 @@ msgstr ""
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr ""
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr ""
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr ""
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr ""
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr ""
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr ""
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr ""
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr ""
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr ""
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr ""
 
@@ -206,85 +226,133 @@ msgstr ""
 msgid "Really delete all list?"
 msgstr ""
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr ""
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr ""
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr ""
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr ""
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr ""
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 msgid "Show \"EPG import now\" in main menu"
 msgstr ""
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr ""
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr ""
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr ""
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr ""
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr ""
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr ""
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr ""
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr ""
 
-#: ../plugin.py:81
-msgid "Tuesday"
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
 msgstr ""
 
 #: ../plugin.py:82
+msgid "Tuesday"
+msgstr ""
+
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr ""
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr ""
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/ar.po
+++ b/src/EPGImport/locale/ar.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-20 02:30+0300\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2020-10-01 16:11+0300\n"
 "Last-Translator: mosad - مساعد الجعيد <abo-mishal@hotmail.com>\n"
 "Language-Team: mosad - مساعد الجعيد\n"
@@ -13,6 +13,7 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
 "X-Generator: Poedit 2.4.1\n"
 
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,69 +25,119 @@ msgstr ""
 "قد يستغرق هذا بضع دقائق.\n"
 "هل هذا جيد؟"
 
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " الاحداث\n"
 
+#: ../filtersServices.py:139
 msgid "Add Channel"
 msgstr "إضافة قناة"
 
+#: ../filtersServices.py:138
 msgid "Add Provider"
 msgstr "إضافة مزود خدمة"
 
+#: ../filtersServices.py:248
 msgid "All services provider"
 msgstr "جميع مقدمي الخدمات"
 
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "إستيراد دليل البرامج الإلكترونية الآلي"
 
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "الإستيراد التلقائي لدليل البرامج الإلكتروينة"
 
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "وقت بدء التشغيل التلقائي"
 
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "إلغاء"
 
+#: ../filtersServices.py:240
+#, fuzzy
+msgid "Channel Selection"
+msgstr "حدد الاجراء"
+
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "أختار الأيام لبدء الاستيراد"
 
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "مسح"
 
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "مسح دليل البرامج الإلكتروني الحالي قبل الاستيراد"
 
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "ضع في اعتبارك تعيين \"ملف تعريف الأيام\""
 
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "ملف تعريف الأيام"
 
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
+
+#: ../filtersServices.py:216
 msgid "Delete all"
 msgstr "حذف الكل"
 
+#: ../filtersServices.py:215
 msgid "Delete selected"
 msgstr "حذف المحدد"
 
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "إعدادات إستيراد دليل البرامج الإلكترونية"
 
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "سجل إستيراد دليل البرامج الإلكترونية"
 
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "مصادر إستيراد دليل البرامج الإلكترونية"
 
+#: ../plugin.py:730
+#, python-format
 msgid "EPG Import finished, %d events"
 msgstr "إنتهاء إستيراد دليل البرامج الإلكترونية, %d الأحداث"
 
-msgid "EPG Importer"
+#: ../plugin.py:702
+#, fuzzy
+msgid "EPG import now"
+msgstr "سجل إستيراد دليل البرامج الإلكترونية"
+
+#: ../plugin.py:1027 ../plugin.py:1032
+#, fuzzy
+msgid "EPGImport"
 msgstr "إستيراد دليل البرامج الإلكترونية"
 
-msgid "EPG-Importer"
-msgstr "إستيراد دليل البرامج الإلكترونية"
-
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -94,6 +145,7 @@ msgstr ""
 "إستيراد الدليل الالكتروني\n"
 "لا يزال استيراد بيانات الدليل الالكتروني قيد التنفيذ. الرجاء الانتظار."
 
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -105,6 +157,7 @@ msgstr ""
 "قد يستغرق هذا بضع دقائق.\n"
 "هل هذا جيد؟"
 
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -112,15 +165,32 @@ msgstr ""
 "بلجن إستيراد الدليل الاكتروني\n"
 "فشل بدء الاستيراد:\n"
 
+#: ../plugin.py:313
+#, python-format
+msgid ""
+"Filtering: %s\n"
+"Please wait!"
+msgstr ""
+
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "الجمعه"
 
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "تجاهل قائمة القنوات"
 
+#: ../filtersServices.py:153
+#, fuzzy
+msgid "Ignore services list(press OK to save)"
+msgstr "تجاهل قائمة القنوات"
+
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "استيراد المصدر الحالي"
 
+#: ../plugin.py:314
+#, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
@@ -128,96 +198,170 @@ msgstr ""
 "المستورد: %s\n"
 "%s الاحداث"
 
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "آخر استيراد: "
 
+#: ../plugin.py:436
+#, python-format
 msgid "Last import: %s events"
 msgstr "آخر استيراد: %s الاحداث"
 
+#: ../plugin.py:431
+#, python-format
 msgid "Last: %s %s, %d events"
 msgstr "أخر: %s %s, %d الاحداث"
 
-msgid "Load EPG only for IPTV channels"
-msgstr "تحميل دليل البرامج الإلكترونية لقنوات الايبي تيفي فقط"
-
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "تحميل دليل البرامج الإلكترونية فقط للقنوات الموجودة في الباقات"
 
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "تحميل وصف مطول إضغط على عدد الايام"
 
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "يدوي"
 
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "الاثنين"
 
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "لا توجد مصادر لدليل البرامج الإلكترونية مفعلة، عليك أن تفعل شيئا"
 
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "أضغط موافق"
 
+#: ../filtersServices.py:182
 msgid "Really delete all list?"
 msgstr "حقا تريد حذف جميع القائمة؟"
 
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "العودة إلى وضع الاستعداد العميق بعد الاستيراد"
 
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "تشغيل المؤقت التلقائي بعد الاستيراد"
 
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "السبت"
 
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "حفظ"
 
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "حدد الاجراء"
 
-msgid "Select service to add..."
-msgstr "أختار القناة لإضافتها..."
-
-msgid "Show \"EPG Importer\" in main menu"
+#: ../plugin.py:334
+#, fuzzy
+msgid "Show \"EPG import now\" in main menu"
 msgstr "عرض \"دليل البرامج الإلكترونية المستوردة\" في القائمة الرئيسية"
 
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "عرض \"إستيراد دليل البرامج الإلكترونية\" في الملحقات"
 
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "عرض السجل"
 
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "تخطي الاستيراد عند إعادة تشغيل الانجما"
 
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "المصادر"
 
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "الاستعداد عند بدء التشغيل"
 
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "تشغيل الإستيراد بعد الإقلاع"
 
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "الاحد"
 
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "الخميس"
 
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "الثلاثاء"
 
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "الاربعاء"
 
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "عندما تكون في وضع الاستعداد العميق"
 
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "الكتابة في مسار سجل إستيراد الدليل"
 
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -225,6 +369,7 @@ msgstr ""
 "لا يجوز لك استخدام هذه الإعدادات!\n"
 "يجب تضمين يوم واحد على الأقل في الأسبوع!"
 
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -232,23 +377,26 @@ msgstr ""
 "يجب إعادة تشغيل الانجما لتحميل بيانات دليل البرامج الإلكتروني,\n"
 "هل هذا جيد؟"
 
+#: ../plugin.py:51
 msgid "always"
 msgstr "دائما"
 
+#: ../plugin.py:54
 msgid "never"
 msgstr "أبدا"
 
+#: ../plugin.py:53
 msgid "only automatic boot"
 msgstr "أثناء التشغيل التلقائي فقط"
 
+#: ../plugin.py:52
 msgid "only manual boot"
 msgstr "أثناء التشغيل اليدوي فقط"
 
-msgid "press OK to save list"
-msgstr "اضغط موافق لحفظ القائمة"
-
+#: ../plugin.py:62
 msgid "skip the import"
 msgstr "تخطي عملية الاستيراد"
 
+#: ../plugin.py:61
 msgid "wake up and import"
 msgstr "بعد التشغيل والاستيراد"

--- a/src/EPGImport/locale/cs.po
+++ b/src/EPGImport/locale/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: enigma2-plugins 3.2.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2012-05-17 14:10+0000\n"
 "Last-Translator: jerry\n"
 "Language-Team: jerry\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -25,7 +25,7 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr ""
 
@@ -41,22 +41,26 @@ msgstr ""
 msgid "All services provider"
 msgstr ""
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr ""
 
 #
-#: ../plugin.py:315
+#: ../plugin.py:323
 #, fuzzy
 msgid "Automatic import EPG"
 msgstr "Denní automatický import"
 
 #
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Čas automatického spuštění"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr ""
 
@@ -64,24 +68,32 @@ msgstr ""
 msgid "Channel Selection"
 msgstr ""
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr ""
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr ""
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr ""
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
+msgstr ""
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
 msgstr ""
 
 #: ../filtersServices.py:216
@@ -92,46 +104,54 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
 #
-#: ../plugin.py:282
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Nastavení importu EPG"
 
 #
-#: ../plugin.py:638
+#: ../plugin.py:662
 #, fuzzy
 msgid "EPG Import Log"
 msgstr "Zdroje importu EPG"
 
 #
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Zdroje importu EPG"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr ""
 
 #
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Zdroje importu EPG"
 
 #
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 #, fuzzy
 msgid "EPGImport"
 msgstr "Zdroje importu EPG"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
 msgstr ""
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -139,24 +159,24 @@ msgid ""
 "Is this ok?"
 msgstr ""
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
 msgstr ""
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr ""
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr ""
 
@@ -165,55 +185,55 @@ msgid "Ignore services list(press OK to save)"
 msgstr ""
 
 #
-#: ../plugin.py:513
+#: ../plugin.py:537
 #, fuzzy
 msgid "Import current source"
 msgstr "Zdroje importu EPG"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr ""
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr ""
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr ""
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr ""
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
 #
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Načíst dlouhé popisy po X dnech"
 
 #
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Ručně"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr ""
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr ""
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr ""
 
@@ -221,93 +241,141 @@ msgstr ""
 msgid "Really delete all list?"
 msgstr ""
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr ""
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr ""
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr ""
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr ""
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr ""
 
 #
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Zobrazit v zozšířeních"
 
 #
-#: ../plugin.py:325
+#: ../plugin.py:333
 #, fuzzy
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Zobrazit v zozšířeních"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr ""
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr ""
 
 #
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Zdroje"
 
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
 #
-#: ../plugin.py:319
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Uspat po spuštění"
 
 #
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Importovat po nabootování"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr ""
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr ""
 
-#: ../plugin.py:81
-msgid "Tuesday"
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
 msgstr ""
 
 #: ../plugin.py:82
+msgid "Tuesday"
+msgstr ""
+
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr ""
 
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
 #
-#: ../plugin.py:317
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Při vypnutém stavu"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/de.po
+++ b/src/EPGImport/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2016-04-09 19:09+0200\n"
 "Last-Translator: edcrane\n"
 "Language-Team: none\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.8.7\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -30,7 +30,7 @@ msgstr ""
 "wird bis zu einigen Minuten dauern.\n"
 "Ist das OK?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " Ereignisse\n"
 
@@ -46,19 +46,23 @@ msgstr "Senderkette hinzufügen"
 msgid "All services provider"
 msgstr "Alle Senderketten"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatisierter EPG-Import"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "EPG automatisch importieren"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Startzeit"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Abbrechen"
 
@@ -66,25 +70,33 @@ msgstr "Abbrechen"
 msgid "Channel Selection"
 msgstr "Kanalauswahl"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Nur an bestimmten Tagen importieren"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Löschen"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "EPG vor dem Import löschen"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Ausgewählte Tage berücksichtigen"
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Import an bestimmten Tagen"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -94,34 +106,42 @@ msgstr "Alle löschen"
 msgid "Delete selected"
 msgstr "Ausgewählte löschen"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "EPG-Import-Konfiguration"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG-Import-Log"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG-Import-Quellen"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG-Import abgeschlossen, %d Ereignisse"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "EPG-Import-Log"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -129,7 +149,7 @@ msgstr ""
 "EPGImport\n"
 "Import der EPG-Daten läuft noch. Bitte warten."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -141,7 +161,7 @@ msgstr ""
 "wird bis zu einigen Minuten dauern.\n"
 "Ist das OK?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -149,18 +169,18 @@ msgstr ""
 "EPGImport Plugin\n"
 "Nicht gestartet:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Freitag"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Liste der zu überspringenden Sender"
 
@@ -168,11 +188,11 @@ msgstr "Liste der zu überspringenden Sender"
 msgid "Ignore services list(press OK to save)"
 msgstr "Liste der zu überspringenden Sender (OK zum Speichern)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Aktuelle Quelle importieren"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -181,41 +201,41 @@ msgstr ""
 "Importiere: %s\n"
 "%s Ereignisse"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Letzter Import: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Letzter Import: %s Ereignisse"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Letzte: %s %s, %d Ereignisse"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "EPG nur für Sender aus Favoritenlisten aktualisieren"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Lade lange Beschreibungen bis zu X Tage"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manuell"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Montag"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Keine aktiven EPG-Quellen gefunden, nichts zu tun"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "OK drücken"
 
@@ -223,81 +243,129 @@ msgstr "OK drücken"
 msgid "Really delete all list?"
 msgstr "Wirklich die gesamte Liste löschen?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Nach Import in den Tiefschlaf zurückkehren"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Nach Import AutoTimer starten"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Samstag"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Sichern"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Aktion auswählen"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "\"EPG-Importer\" im Hauptmenü anzeigen"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "\"EPG-Import\" unter Erweiterungen anzeigen"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Log anzeigen"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Import bei GUI-Neustart überspringen"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Quellen"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Standby beim Start"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Import nach dem Booten starten"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Sonntag"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Donnerstag"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Dienstag"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Mittwoch"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Wenn ausgeschaltet"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 #, fuzzy
 msgid "Write to /tmp/epgimport.log"
 msgstr "Nach /tmp/EPGimport.log schreiben"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -305,7 +373,7 @@ msgstr ""
 "Sie können diese Einstellung nicht nutzen!\n"
 "Mindestens ein Tag muß ausgewählt sein!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/el.po
+++ b/src/EPGImport/locale/el.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPG Import\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: \n"
 "Last-Translator: MCelliot_g <mcelliot_g@hotmail.com>\n"
 "Language-Team: \n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.0.6\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,7 +24,7 @@ msgstr ""
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά.\n"
 "Είναι αυτό εντάξει;"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " προγράμματα\n"
 
@@ -40,19 +40,23 @@ msgstr "Προσθήκη Παρόχου"
 msgid "All services provider"
 msgstr "Πάροχος όλων των υπηρεσιών"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Αυτοματοποιημένη Eισαγωγή EPG"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Αυτόματη εισαγωγή EPG"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Αυτόματη ώρα έναρξης"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Ακύρωση"
 
@@ -60,25 +64,33 @@ msgstr "Ακύρωση"
 msgid "Channel Selection"
 msgstr "Επιλογή Καναλιών"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Επιλογή ημερών για εκκίνηση εισαγωγής"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Καθαρισμός"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Καθαρισμός τρέχοντος EPG πριν την εισαγωγή"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Υπενθύμιση ρύθμισης του \"Προφίλ Ημερών\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Προφίλ Ημερών"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -88,33 +100,41 @@ msgstr "Διαγραφή όλων"
 msgid "Delete selected"
 msgstr "Διαγραφή επιλεγμένων"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Ρυθμίσεις Εισαγωγής EPG"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Καταγραφή Εισαγωγής EPG"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Πηγές Εισαγωγής EPG"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Η εισαγωγή EPG ολοκληρώθηκε, %d προγράμματα"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Καταγραφή Εισαγωγής EPG"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "Εισαγωγή EPG"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -122,7 +142,7 @@ msgstr ""
 "Εισαγωγή EPG\n"
 "Η εισαγωγή των δεδομένων EPG είναι ακόμα σε εξέλιξη. Περιμένετε..."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -134,7 +154,7 @@ msgstr ""
 "Αυτό μπορεί να διαρκέσει μερικά λεπτά.\n"
 "Είναι αυτό εντάξει;"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -142,18 +162,18 @@ msgstr ""
 "Πρόσθετο EPGImport\n"
 "Αδυναμία εκκίνησης:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Παρασκευή"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Αγνόηση λίστας υπηρεσιών"
 
@@ -161,11 +181,11 @@ msgstr "Αγνόηση λίστας υπηρεσιών"
 msgid "Ignore services list(press OK to save)"
 msgstr "Αγνόηση λίστας υπηρεσιών (πιέστε ΟΚ για αποθήκευση)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Εισαγωγή τρέχουσας πηγής"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -174,41 +194,41 @@ msgstr ""
 "Εισαγωγή σε εξέλιξη: %s\n"
 "%s προγράμματα"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Τελευταία εισαγωγή: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Τελευταία εισαγωγή: %s προγράμματα"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Τελευταίο: %s %s, %d προγράμματα"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Φόρτωση μόνο υπηρεσιών με EPG στα μπουκέτα"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Φόρτωση εκτεταμένων περιγραφών έως και Χ ημέρες"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Χειροκίνητα"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Δευτέρα"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Δεν βρέθηκαν ενεργές πηγές EPG, καμία ενέργεια"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Πιέστε ΟΚ"
 
@@ -216,80 +236,128 @@ msgstr "Πιέστε ΟΚ"
 msgid "Really delete all list?"
 msgstr "Να διαγραφούν σίγουρα όλες οι λίστες;"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Επιστροφή σε βαθιά αναμονή μετά την εισαγωγή"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Εκτέλεση Αυτόματου Χρονοδιακόπτη μετά την εισαγωγή"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Σάββατο"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Επιλογή ενέργειας"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Εμφάνιση της \"Εισαγωγής EPG\" στο κύριο μενού"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Εμφάνιση της \"Εισαγωγής EPG\" στις επεκτάσεις"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Εμφάνιση καταγραφής"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Παράκαμψη εισαγωγής κατά την επανεκκίνηση του GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Πηγές"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Αναμονή κατά την εκκίνηση"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Έναρξη εισαγωγής μετά την εκκίνηση"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Κυριακή"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Πέμπτη"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Τρίτη"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Τετάρτη"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Σε βαθιά αναμονή"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Εγγραφή στο /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -297,7 +365,7 @@ msgstr ""
 "Μπορείτε να μη χρησιμοποιήσετε αυτές τις ρυθμίσεις!\n"
 "Πρέπει να συμπεριλαμβάνεται τουλάχιστον μία ημέρα της εβδομάδας!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/en_GB.po
+++ b/src/EPGImport/locale/en_GB.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2012-03-05 22:57+0000\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 #, fuzzy
 msgid ""
 "\n"
@@ -30,7 +30,7 @@ msgstr ""
 "This may take a few minutes\n"
 "Is this ok?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr ""
 
@@ -46,20 +46,24 @@ msgstr ""
 msgid "All services provider"
 msgstr ""
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automated EPG Importer"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 #, fuzzy
 msgid "Automatic import EPG"
 msgstr "Daily automatic import"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automatic start time"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -67,24 +71,32 @@ msgstr "Cancel"
 msgid "Channel Selection"
 msgstr ""
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr ""
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Clear"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr ""
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
+msgstr ""
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
 msgstr ""
 
 #: ../filtersServices.py:216
@@ -95,34 +107,42 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "EPG Import Configuration"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG Import Log"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG Import Sources"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG Import finished, %d events"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "EPG Import Log"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -131,7 +151,7 @@ msgstr ""
 "EPGImport Plugin\n"
 "Import of epg data is still in progress. Please wait."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -144,7 +164,7 @@ msgstr ""
 "This may take a few minutes\n"
 "Is this ok?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -152,18 +172,18 @@ msgstr ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr ""
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr ""
 
@@ -171,53 +191,53 @@ msgstr ""
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 #, fuzzy
 msgid "Import current source"
 msgstr "EPG Import Sources"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, fuzzy, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr "EPG Import finished, %d events"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr ""
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, fuzzy, python-format
 msgid "Last import: %s events"
 msgstr "Last: %s %s, %d events"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Last: %s %s, %d events"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Load long descriptions up to X days"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manual"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr ""
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "No active EPG sources found, nothing to do"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr ""
 
@@ -225,87 +245,135 @@ msgstr ""
 msgid "Really delete all list?"
 msgstr ""
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr ""
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr ""
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr ""
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Save"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr ""
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Show in extensions"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 #, fuzzy
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Show in extensions"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr ""
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr ""
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Sources"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Standby at startup"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Start import after booting up"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr ""
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr ""
 
-#: ../plugin.py:81
-msgid "Tuesday"
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
 msgstr ""
 
 #: ../plugin.py:82
+msgid "Tuesday"
+msgstr ""
+
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr ""
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "When in deep standby"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/es.po
+++ b/src/EPGImport/locale/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2018-05-22 18:19+0200\n"
 "Last-Translator: Javier Sayago <admin@lonasdigital.com>\n"
 "Language-Team: OpenLD\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.0.7\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -30,7 +30,7 @@ msgstr ""
 "Esto puede tomar unos pocos minutos.\n"
 "¿Es correcto?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " Eventos\n"
 
@@ -46,19 +46,23 @@ msgstr "Agregar proveedor"
 msgid "All services provider"
 msgstr "Todos los proveedores de servicios"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatizar EPG-Import"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Importar EPG automáticamente"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Hora del inicio automático"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -66,25 +70,33 @@ msgstr "Cancelar"
 msgid "Channel Selection"
 msgstr "Selección del canal"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Días de elección para la importación inicial"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Borrar"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Eliminar EPG antes de importar"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Considerar los días seleccionados"
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Importación en ciertos días"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -94,33 +106,41 @@ msgstr "Eliminar todos"
 msgid "Delete selected"
 msgstr "Eliminar seleccionado"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Configuración EPG-Import"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG-Import-Log"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG-Import-Fuentes"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG-Import terminó, %d Eventos"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "EPG-Import-Log"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -128,7 +148,7 @@ msgstr ""
 "EPGImport\n"
 "La importación de los datos EPG está en curso. Por favor, espere."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -140,7 +160,7 @@ msgstr ""
 "Esto puede tardar unos minutos.\n"
 "¿Está conforme?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -148,18 +168,18 @@ msgstr ""
 "EPGImport Plugin\n"
 "Error al iniciar:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Viernes"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Ignorar lista de servicios"
 
@@ -167,11 +187,11 @@ msgstr "Ignorar lista de servicios"
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorar lista de servicios (presione OK para guardar)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importar fuente actual"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -180,41 +200,41 @@ msgstr ""
 "Importación: %s\n"
 "%s Eventos"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Última importación:: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Última importación: %s Eventos"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Último: %s %s, %d Eventos"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Cargar servicios de EPG únicamente en bouquets"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Cargar descripciones largas hasta X días"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manual"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Lunes"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "No se encontraron fuentes de EPG activas, nada que hacer"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Pulse OK"
 
@@ -222,80 +242,128 @@ msgstr "Pulse OK"
 msgid "Really delete all list?"
 msgstr "¿Realmente elimina toda la lista?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Volver al modo de espera profundo después de la importación"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Ejecutar AutoTimer después de importar"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Sábado"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Guardar"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Seleccionar acción"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Mostrar \"EPG Importer\" en el menú principal"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Mostrar \"EPG Importer\" en extensiones"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Mostrar log"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Omitir importación al reiniciar GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Fuentes"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "En espera al inicio"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Iniciar importación después de arrancar"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Domingo"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Jueves"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Martes"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Miércoles"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Cuando está en modo de espera profundo"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Escribir en /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -303,7 +371,7 @@ msgstr ""
 "¡No puedes usar esta configuración!\n"
 "Por lo menos un día a la semana debe ser incluido."
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/et.po
+++ b/src/EPGImport/locale/et.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: XMTV-Impoter for Enigma2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2017-08-30 12:21+0300\n"
 "Last-Translator: rimas\n"
 "Language-Team: rimas\n"
@@ -14,7 +14,7 @@ msgstr ""
 "X-Poedit-SourceCharset: utf-8\n"
 "X-Generator: Poedit 2.0.3\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -26,7 +26,7 @@ msgstr ""
 "See võib kesta mõne minuti\n"
 "Kas see sobib?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " saadet\n"
 
@@ -42,19 +42,23 @@ msgstr "Lisa levitaja"
 msgid "All services provider"
 msgstr "Levitaja kõigile kanalitele"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automaatne EPG import"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Hangi EPG automaatselt"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automaatse käivituse aeg"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Tühista"
 
@@ -62,25 +66,33 @@ msgstr "Tühista"
 msgid "Channel Selection"
 msgstr "Kanalivalik"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Päev EPG hankimiseks"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Kustuta"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Aktiivse EPG eemaldamine enne importi"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Seadista \"päevade profiil\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Päevade profiil"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -90,33 +102,41 @@ msgstr "Kustuta  kõik"
 msgid "Delete selected"
 msgstr "Kustuta valik"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Seadistamine"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG impordi logi"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG impordi allikad"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG hankimine lõpetatud, %d saadet"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "EPG impordi logi"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPGImport"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -124,7 +144,7 @@ msgstr ""
 "EPG import\n"
 "Epg hankimine on pooleli. Oota."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -136,7 +156,7 @@ msgstr ""
 "See võib kesta mõne minuti\n"
 "Kas see sobib?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -144,18 +164,18 @@ msgstr ""
 "EPGImport\n"
 "Käivitamine nurjus:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Reede"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Eiratav kanalinimekiri"
 
@@ -163,11 +183,11 @@ msgstr "Eiratav kanalinimekiri"
 msgid "Ignore services list(press OK to save)"
 msgstr "Eiratav (salvestamiseks vajuta OK)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Import valitud allikast"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -176,41 +196,41 @@ msgstr ""
 "Import: %s\n"
 "%s saadet"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Viimati: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Viimati: %s saadet"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Viimati: %s %s, %d saadet"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "EPG ainult kanalitele lemmiknimekirjades"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Pikk saatetutvustus X päevaks"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Käsitsi"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Esmaspäev"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "EPG allikad on määramata. Midagi ei saa teha"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Vajuta OK"
 
@@ -218,80 +238,128 @@ msgstr "Vajuta OK"
 msgid "Really delete all list?"
 msgstr "Kas kustutada kogu nimekiri?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Pärast importi tagasi puhkeseisundisse"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Käivita Autotaimer pärast importi"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Laupäev"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Salvesta"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Vali tegevus"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Kuva \"EPG import\" peamenüüs"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Kuva \"EPG import\" laienduste menüüs"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Kuva logi"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Ära impordi pärast E2 taaskäivitust"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Allikad"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Käivitamine ooteseisundist"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Hangi EPG pärast alglaadimist"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Pühapäev"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Neljapäev"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Teisipäev"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Kolmapäev"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Puhkeseisundis"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Kirjuta /tmp/epgimport.log  faili"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -299,7 +367,7 @@ msgstr ""
 "Seda seadistust ei saa kasutada!\n"
 "Tuleb valida vähemalt üks päev või nädal!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/fi.po
+++ b/src/EPGImport/locale/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: plugins 0.0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2016-05-17 12:41+0200\n"
 "Last-Translator: Samzam <http://www.world-of-satellite.com>\n"
 "Language-Team: none\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.7\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -30,7 +30,7 @@ msgstr ""
 "Tämä voi kestää muutaman minuutin.\n"
 "Onko tämä OK?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " tapahtumia\n"
 
@@ -46,19 +46,23 @@ msgstr ""
 msgid "All services provider"
 msgstr ""
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automaattinen EPG:n lataus"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Automaattinen EPG lataus"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Aloitusaika"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Poistu"
 
@@ -66,25 +70,33 @@ msgstr "Poistu"
 msgid "Channel Selection"
 msgstr ""
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Valitse latauspäivät"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Tyhjennä"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Tyhjennä nykyinen EPG ennen latausta"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Harkitse asetusta \"Valitse päivät\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Valitse päivät"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -94,34 +106,42 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Asetukset"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Loki"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Lähteet"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Lataus valmis, %d tapahtumaa"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Loki"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG:n lataus"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -129,7 +149,7 @@ msgstr ""
 "EPG:n lataus\n"
 "EPG:n lataus käynnissä. Odota."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -141,7 +161,7 @@ msgstr ""
 "Tämä voi kestää muutaman minuutin.\n"
 "Onko tämä OK?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -149,18 +169,18 @@ msgstr ""
 "EPG lataus\n"
 " Käynnistys epäonnistui:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Perjantai"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr ""
 
@@ -168,11 +188,11 @@ msgstr ""
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Lataa tämä lähde"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -181,41 +201,41 @@ msgstr ""
 "Lataa: %s\n"
 "%s events"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Viimeisin lataus: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Viimeisin lataus: %s tapahtumaa"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Ladattu: %s %s, %d tapahtumaa"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Lataa EPG vain suosikkilistojen kanaville"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Lataa ohjelmakuvaukset X päivälle"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Lataa nyt"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Maanantai"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Ei löytynyt aktiivisia EPG lähteitä"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Paina OK"
 
@@ -223,81 +243,129 @@ msgstr "Paina OK"
 msgid "Really delete all list?"
 msgstr ""
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Palaa virransäästötilaan latauksen jälkeen"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Käynnistä automaattiajastusten haku latauksen jälkeen"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Lauantai"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Tallenna"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr ""
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Näytä \"EPG:n lataus\" päävalikossa"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Näytä \"EPG:n lataus\" laajennusvalikossa"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr ""
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Ohita lataus uudelleenkäynnistyksessä"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Lähteet"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Valmiustilassa lataus"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Lataa uudelleenkäynnistyksen jälkeen"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Sunnuntai"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Torstai"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Tiistai"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Keskiviikko"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Virransäästötilassa lataus"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 #, fuzzy
 msgid "Write to /tmp/epgimport.log"
 msgstr "Kirjoita lokiin /tmp/EPGimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -305,7 +373,7 @@ msgstr ""
 "Et voi käyttää tätä asetusta!\n"
 "Vähintään yksi päivä pitää valita!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/fr.po
+++ b/src/EPGImport/locale/fr.po
@@ -2,17 +2,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
-"PO-Revision-Date: 2020-05-23 18:08+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
+"PO-Revision-Date: 2021-04-08 15:35+0200\n"
 "Last-Translator: demosat\n"
 "Language-Team: LANGUAGE <dummy@dummy.fr>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.4.2\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,7 +24,7 @@ msgstr ""
 "Cela va durer quelques minutes.\n"
 "Êtes-vous d'accord ?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " évènements\n"
 
@@ -40,19 +40,23 @@ msgstr "Ajouter un fournisseur"
 msgid "All services provider"
 msgstr "Tous les services du fournisseur"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr "Appliquer aussi le filtrage du \"channel id\" sur le custom.channels.xml"
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Importation EPG automatique"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Importation EPG automatique"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Heure de démarrage automatique"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Annuler"
 
@@ -60,25 +64,33 @@ msgstr "Annuler"
 msgid "Channel Selection"
 msgstr "Sélection des chaînes"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Choisir les jours pour démarrer l’import"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr "Choisissez l’action à effectuer lorsque le récepteur est en veille profonde et que la mise à jour automatique de l’EPG doit commencer."
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Effacer"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Effacer l'EPG actuel avant l'importation"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Considérer le profil « Profil des jours »"
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Profil des jours"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr "Définissez le nombre de jours dont vous souhaitez obtenir les données EPG complètes, cela peut vous aider à limiter l’utilisation de la mémoire sur votre récepteur. Mais vous êtes également limité par les données disponibles par le fournisseur d'EPG. Vous n’aurez pas 15 jours d'EPG s'il ne fournit que les données pour 7 jours."
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -88,32 +100,40 @@ msgstr "Tout effacer"
 msgid "Delete selected"
 msgstr "Effacer les sélectionner"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr "Affichez un raccourci «Importer EPG maintenant » sur l'écran principal de votre récepteur. Cette entrée du menu démarre immédiatement le processus de mise à jour de l'EPG."
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr "Affichez ou non le menu EPGImport dans le menu d’extension."
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Configuration EPG import"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Log EPG Import"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Sources pour EPG Import"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG Import terminé, %d évènements"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 msgid "EPG import now"
 msgstr "Importer l’EPG maintenant"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPGImport"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -121,7 +141,7 @@ msgstr ""
 "EPGImport Plugin\n"
 "L'import des données EPG est encore en cours. Merci de patienter."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -133,7 +153,7 @@ msgstr ""
 "Cela va durer quelques minutes.\n"
 "Êtes-vous d'accord ?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -141,7 +161,7 @@ msgstr ""
 "EPGImport Plugin\n"
 "Echec du démarrage:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
@@ -150,11 +170,11 @@ msgstr ""
 "Filtrage: %s\n"
 "Merci de patienter!"
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Vendredi"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Liste des services à ignorer"
 
@@ -162,11 +182,11 @@ msgstr "Liste des services à ignorer"
 msgid "Ignore services list(press OK to save)"
 msgstr "Liste des services à ignorer (appuyez sur OK pour sauvegarder)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importer la source actuelle"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -175,41 +195,41 @@ msgstr ""
 "Importation: %s\n"
 "%s évènements"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Dernier import: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Dernier import: %s évènements"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Dernier: %s %s, %d évènements"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Charger EPG uniquements pour les favoris"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Charger les descriptions longues jusqu'à X jours"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manuel"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Lundi"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Aucune source EPG sélectionnée, rien à faire"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Appuyez sur OK"
 
@@ -217,79 +237,127 @@ msgstr "Appuyez sur OK"
 msgid "Really delete all list?"
 msgstr "Vraiment effacer toute la liste?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Retour à veille profonde après l'importation"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Exécutez AutoTimer après l'importation"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Samedi"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Choisir une action"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Afficher « Importer l’EPG maintenant » dans le menu principal"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Afficher « EPGImport » dans le menu extension"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Afficher le log"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Eviter l'import au redémarrage GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Sources"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr "Spécifiez dans quel cas l’EPG doit être automatiquement être mis à jour après le démarrage du récepteur."
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr "Spécifiez l’heure de la mise à jour automatique de l’EPG."
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Démarrer en veille"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Charger import après le démarrage"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Dimanche"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr "Votre récepteur sera remis en veille après un réveil automatique pour l'importation automatique de l'EPG."
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr "Cela permettra d’effacer les données EPG actuelles avant de mettre à jour les données de celui-ci. Cela vous permet d’avoir toujours les données EPG les plus récentes, en cas de changements de programme entre deux importations, sinon les données EPG sont cumulatives."
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr "Votre récepteur qui a été réveillé, sera remis en veille profonde après une importation de l'EPG."
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Jeudi"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr "Pour limiter l'utilisation mémoire, vous pouvez décider de charger les données EPG uniquement pour les services dans vos favoris."
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Mardi"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr "Lorsqu’il est activé, il vous permet de planifier une mise à jour EPG automatique aux jours et à l’heure donnés."
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Lorsqu'il est en veille profonde"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr "Lorque le fichier /etc/epgimport/channel_id_filter.conf existe et qu'il contient des expressions régulières (regex) valident, son contenu sera appliqué comme filtre sur tous les fichiers de données EPG. Mais vous pouvez choisir si le filtrage doit être appliqué ou pas sur votre fichier /etc/epgimport/custom.channels.xml"
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr "Vous pouvez choisir d'importer l'EPG après un redémarrage de l'IGU tout en respectant le \"profil des jours\" ou pas."
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr "Lorsque vous redémarrez l’IGU, vous pouvez décider de sauter ou non l’importation de données EPG."
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Écrire dans /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr "Vous pouvez choisir le(s) jour(s) où l'EPG doit être mis à jour."
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr "Vous pouvez déclencher automatiquement le plugin AutoTimer après la mise à jour des données EPG pour que celui-ci remette à jour ses programmation après un rafraîchissement des données de l'EPG."
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -297,7 +365,7 @@ msgstr ""
 "Vous ne pouvez pas utiliser ces paramètres!\n"
 "Au moins un jour par semaine devrait être inclus!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"
@@ -315,7 +383,7 @@ msgstr "jamais"
 
 #: ../plugin.py:53
 msgid "only automatic boot"
-msgstr "seulement au démarrage auto."
+msgstr "seulement au démarrage automatique"
 
 #: ../plugin.py:52
 msgid "only manual boot"

--- a/src/EPGImport/locale/hu.po
+++ b/src/EPGImport/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2019-02-18 11:40+0100\n"
 "Last-Translator: mcfly82\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 2.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -30,7 +30,7 @@ msgstr ""
 "Ez néhány percet igénybe vesz.\n"
 "Folytathatjuk?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " esemény\n"
 
@@ -46,19 +46,23 @@ msgstr "Szolgáltató hozzáadása"
 msgid "All services provider"
 msgstr "Minden szolgáltató"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatikus EPG importáló"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Automatikus EPG importálás"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automatikus importálás időpontja"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Mégsem"
 
@@ -66,25 +70,33 @@ msgstr "Mégsem"
 msgid "Channel Selection"
 msgstr "Csatornaválasztás"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Importálások napjai"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Alaphelyzet"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Előző EPG felülírása az újjal"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Napi profil használata"
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Napi profilok"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -94,33 +106,41 @@ msgstr "Összes törlése"
 msgid "Delete selected"
 msgstr "Kijelöltek törlése"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "EPG Import beállítások"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG Import napló"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG Import források"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG Import befejezve, %d esemény"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "EPG Import napló"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPG Import"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -128,7 +148,7 @@ msgstr ""
 "EPGImport\n"
 "Az EPG adatok importálása folyamatban van. Kérem, várjon."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -140,7 +160,7 @@ msgstr ""
 "Ez néhány percet igénybe vesz.\n"
 "Folytathatjuk?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -148,7 +168,7 @@ msgstr ""
 "Az EPGImport bővítmény\n"
 "Nem tudott elindulni:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
@@ -157,11 +177,11 @@ msgstr ""
 "Szűrés: %s\n"
 "Kérem várjon!"
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Péntek"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Csatornalista kihagyása"
 
@@ -169,11 +189,11 @@ msgstr "Csatornalista kihagyása"
 msgid "Ignore services list(press OK to save)"
 msgstr "Csatornalista kihagyása (Nyomjon OK-t a mentéshez)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Jelenlegi forrás importálása"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -182,41 +202,41 @@ msgstr ""
 "Importálás: %s\n"
 "%s esemény"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Utolsó importálás: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Utolsó importálás: %s esemény"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Frissítve: %s %s, %d esemény"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "EPG betöltése csak a könyvjelzőkben szereplő csatornákhoz"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Hány napra előre töltse be a leírást"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manuális"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Hétfő"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Nincs aktív EPG forrás, nincs mit tenni"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Nyomja meg az OK-t"
 
@@ -224,80 +244,128 @@ msgstr "Nyomja meg az OK-t"
 msgid "Really delete all list?"
 msgstr "Biztosan törli az összes listát?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Kikapcsolás importálás után"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Automatikus időzítő futtatása importálás után"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Szombat"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Mentés"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Válasszon műveletet"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "EPGImport mutatása a főmenüben"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "EPGImport mutatása a bővítményeknél"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Naplófájl megjelenítése"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Importálás kihagyása a kezelőfelület újraindításakor"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Források"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Készenlét indításkor"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Importálás bootolás után"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Vasárnap"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Csütörtök"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Kedd"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Szerda"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Kikapcsolt állapotban"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Írás ide: /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -305,7 +373,7 @@ msgstr ""
 "Valószínűleg nincs szüksége erre a beállításra!\n"
 "Legalább egy napot ki kell választania!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/it.po
+++ b/src/EPGImport/locale/it.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport Italian Translation for Enigma2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2020-08-26 14:01+0200\n"
 "Last-Translator: Alexwilmac\n"
 "Language-Team: vuplus-community\n"
@@ -16,13 +16,7 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 "X-Poedit-SearchPath-0: /EPGImport\n"
 
-msgid "Load EPG only for IPTV channels"
-msgstr "Carica l'EPG solo per i canali IPTV"
-
-msgid "Show \"EPGImport\" in plugins"
-msgstr "Mostra EPG Import fra i plugin"
-
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -34,7 +28,7 @@ msgstr ""
 "Questo processo richiede qualche minuto\n"
 "Procedo?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " eventi\n"
 
@@ -50,19 +44,23 @@ msgstr "Aggiungi provider"
 msgid "All services provider"
 msgstr "Tutti i canali di ogni provider"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Importazione EPG automatizzata"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Importazione EPG automatica"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Orario di avvio automatico"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Annulla"
 
@@ -71,25 +69,33 @@ msgstr "Annulla"
 msgid "Channel Selection"
 msgstr "Selezionare azione"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Seleziona il giorno di avvio importazione"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Cancella"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Cancella EPG corrente prima dell’importazione"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Considera l'impostazione \"Profilo giorni\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Profilo dei giorni"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -99,34 +105,42 @@ msgstr "Cancella tutto"
 msgid "Delete selected"
 msgstr "Elimina selezionato"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Configurazione di EPG Import"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Registro importazione EPG"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Fonti importazione EPG"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Importazione EPG completata, %d eventi"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Registro importazione EPG"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG Importer"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -135,7 +149,7 @@ msgstr ""
 "Importazione dati EPG in corso...\n"
 "Attendere prego."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -146,7 +160,7 @@ msgstr ""
 "Questo processo richiede qualche minuto\n"
 "Procedo?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -154,18 +168,18 @@ msgstr ""
 "Plugin EPG-Import\n"
 "Avvio fallito:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Venerdì"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Ignora l'elenco canali"
 
@@ -174,11 +188,11 @@ msgstr "Ignora l'elenco canali"
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignora l'elenco canali"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importa sorgente"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -187,41 +201,41 @@ msgstr ""
 "Importazione: %s\n"
 "%s eventi"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Ultima importazione: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Ultima importazione: %s canali"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Ultima importazione: %s %s, %d canali"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Carica solo i servizi EPG nei bouquet"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Carica le descrizioni dettagliate fino a (n) giorni"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Scarica"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Lunedì"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Fonti EPG attive non trovate: nessuna operazione svolta"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Premere OK"
 
@@ -229,80 +243,128 @@ msgstr "Premere OK"
 msgid "Really delete all list?"
 msgstr "Sicuro di eliminare tutta la lista?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Spegni di nuovo dopo l'importazione"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Avvia AutoTimer dopo l'aggiornamento"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Sabato"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Salva"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Selezionare azione"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Mostra \"EPG Importer\" nel menu principale"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Mostra \"EPGImport\" nelle estensioni"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Mostra il log"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Salta importazione su riavvio sistema"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Sorgenti"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Standby all'avvio"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Avvia l'importazione dopo il boot"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Domenica"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Giovedì"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Martedì"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Mercoledì"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Quando il box è spento"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Scrittura in /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -310,7 +372,7 @@ msgstr ""
 "Non è possibile utilizzare queste impostazioni!\n"
 "Indicare almeno un giorno della settimana!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/nb.po
+++ b/src/EPGImport/locale/nb.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2021-01-31 13:11+0100\n"
 "Last-Translator: andy1 <dummy@dummy.com>\n"
 "Language-Team: G.Jensen\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,22,-1,-1,-1,-1\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -26,7 +26,7 @@ msgstr ""
 "Dette kan ta noen minutter.\n"
 "Er dette ok?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " program\n"
 
@@ -42,19 +42,23 @@ msgstr "Legg til distributør"
 msgid "All services provider"
 msgstr "Alle distributører"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatisert EPG import"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Automatisk EPG import"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automatisk start tid"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -62,25 +66,33 @@ msgstr "Avbryt"
 msgid "Channel Selection"
 msgstr "Kanal valg"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Velg dager for start av import"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Nullstill"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Fjern gjeldende EPG før ny import"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Vurder oppsett av  \"Dagsprofiler\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Dagsprofiler"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -90,32 +102,40 @@ msgstr "Slett alle"
 msgid "Delete selected"
 msgstr "Slett valgte"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Konfigurasjon av EPG import"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG import logg"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG import kilder"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG import fullført, %d program"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 msgid "EPG import now"
 msgstr "EPG import nå"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPG import"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -123,7 +143,7 @@ msgstr ""
 "EPG import\n"
 "Import av EPG data pågår fortsatt. Vennligst vent."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -135,7 +155,7 @@ msgstr ""
 "Dette kan ta noen minutter.\n"
 "Er dette ok?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -143,7 +163,7 @@ msgstr ""
 "EPG import utvidelsen\n"
 "Feilet under oppstart:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
@@ -152,11 +172,11 @@ msgstr ""
 "Filtrerer: %s\n"
 "Vennligst vent!"
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Fredag"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Ignorer kanallisten"
 
@@ -164,11 +184,11 @@ msgstr "Ignorer kanallisten"
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorer kanallisten (trykk OK for å lagre)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importer gjeldende kilde"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -177,41 +197,41 @@ msgstr ""
 "Importerer:%s\n"
 "%s program"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Siste import: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Siste import: %s program"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Siste: %s %s, %d program"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Last bare EPG tjenester i kanallistene"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Last lange beskrivelser opp til X dager"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manuell"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Mandag"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Ingen aktive EPG kilder funnet, ingenting å gjøre"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Trykk OK"
 
@@ -219,79 +239,127 @@ msgstr "Trykk OK"
 msgid "Really delete all list?"
 msgstr "Vil du virkelig slette alle lister?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Gå tilbake til dyp standby etter import"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Kjør auto timer etter import"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Lørdag"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Lagre"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Velg handling"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Vis \"EPG import\" i hovedmeny"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Vis \"EPG import\" i tilleggsmeny"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Vis logg"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Hopp over import ved omstart av GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Kilder"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Standby ved oppstart"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Start import etter oppstart"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Søndag"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Torsdag"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Tirsdag"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Onsdag"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Når i dyp standby"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Skriv til /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -299,7 +367,7 @@ msgstr ""
 "Innstillingen må ikke nødvendigvis brukes!\n"
 "Minst en dag i uken bør inkluderes!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/nl.po
+++ b/src/EPGImport/locale/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2018-01-08 21:58+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -20,7 +20,7 @@ msgstr ""
 "X-Poedit-Basepath: ..\n"
 "X-Poedit-SearchPath-0: .\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -32,7 +32,7 @@ msgstr ""
 "Dit kan een paar minuten duren\n"
 "Wilt u doorgaan?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " programma's\n"
 
@@ -48,19 +48,23 @@ msgstr "Provider toevoegen"
 msgid "All services provider"
 msgstr "Alle zender providers"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatisch EPG importeren"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Automatisch EPG importeren"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automatische start tijd"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Annuleer"
 
@@ -68,25 +72,33 @@ msgstr "Annuleer"
 msgid "Channel Selection"
 msgstr "Zender keuze"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Selecteer dagen voor importeren"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Wis"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Wis huidige EPG voor importeren"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Overweeg een \"dagen profiel\" te gebruiken"
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Dagenprofiel"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -96,33 +108,41 @@ msgstr "Verwijder alles"
 msgid "Delete selected"
 msgstr "Geselecteerde verwijderen"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "EPG-Import configuratie"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG-Import log"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "EPG-Import bronnen"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG importeren gereed, %d programma's"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "EPG-Import log"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPG-Import"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -130,7 +150,7 @@ msgstr ""
 "EPG-Import\n"
 "Importeren van epg-data is nog bezig. Even geduld."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -142,7 +162,7 @@ msgstr ""
 "Dit kan een enkele minuten duren.\n"
 "Doorgaan?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -150,18 +170,18 @@ msgstr ""
 "EPG-Import Plugin\n"
 "Starten mislukt:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Vrijdag"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Negeer zenderlijst"
 
@@ -169,11 +189,11 @@ msgstr "Negeer zenderlijst"
 msgid "Ignore services list(press OK to save)"
 msgstr "Negeer zenderlijst ( druk OK voor opslaan)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importeer bron"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -182,41 +202,41 @@ msgstr ""
 "Importeert: %s\n"
 "%s programma's"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Laatste import: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Laatste import: %s programma's"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Laatste: %s %s, %d programma's"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Laad enkel EPG van zenders in bouquetten"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Laad uitgebreide beschrijvingen tot-en-met X dagen"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Handmatig"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Maandag"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Geen actieve EPG bronnen gevonden, kan niets doen"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Druk op OK"
 
@@ -224,80 +244,128 @@ msgstr "Druk op OK"
 msgid "Really delete all list?"
 msgstr "Werkelijk alle lijsten wissen?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Weer uitschakelen na de importeren"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Activeer AutoTimer na importeren"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Zaterdag"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Opslaan"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Selecteer actie"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Toon \"EPG importer\" in hoofdmenu"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Toon \"EPG importer\" in extensions"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Toon log"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Importeren overslaan na herstart GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Bronnen"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Stand-by na opstarten"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Start importeren na opstarten"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Zondag"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Donderdag"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Dinsdag"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Woensdag"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Wanneer ontvanger is uitgeschakeld"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Schrijf naar /tmp/EPGimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -305,7 +373,7 @@ msgstr ""
 "U kunt deze instellingen niet gebruiken!\n"
 "Er moet tenminste één dag per week worden ingesteld!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/pl.po
+++ b/src/EPGImport/locale/pl.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2014-04-24 19:01+0100\n"
 "Last-Translator: Mariusz1970 <Mariusz1970@onet.eu>\n"
 "Language-Team: none <Mariusz1970@onet.eu>\n"
@@ -14,7 +14,7 @@ msgstr ""
 "X-Generator: Poedit 1.6.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 #, fuzzy
 msgid ""
 "\n"
@@ -27,7 +27,7 @@ msgstr ""
 "Może to potrwać kilka minut\n"
 "jest ok?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr ""
 
@@ -43,20 +43,24 @@ msgstr ""
 msgid "All services provider"
 msgstr ""
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatyczny EPG Importer"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 #, fuzzy
 msgid "Automatic import EPG"
 msgstr "Codzienny automatyczny import"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automatyczny czas rozpoczęcia"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -64,24 +68,32 @@ msgstr "Anuluj"
 msgid "Channel Selection"
 msgstr ""
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr ""
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Czyść"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr ""
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr ""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
+msgstr ""
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
 msgstr ""
 
 #: ../filtersServices.py:216
@@ -92,34 +104,42 @@ msgstr ""
 msgid "Delete selected"
 msgstr ""
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Konfiguracja EPG Importu"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Import EPG Logi"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Import EPG Źródła"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Import EPG zakończony, %d wydarzenia"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Import EPG Logi"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 #, fuzzy
 msgid "EPGImport"
 msgstr "EPG-Importer"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -128,7 +148,7 @@ msgstr ""
 "Import EPG Plugin\n"
 "Import danych EPG jest nadal w toku. Proszę czekać."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 #, fuzzy
 msgid ""
 "EPGImport\n"
@@ -141,7 +161,7 @@ msgstr ""
 "Może to potrwać kilka minut\n"
 "jest ok?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -149,18 +169,18 @@ msgstr ""
 "Import EPG Plugin\n"
 "Nie powiodło się:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr ""
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr ""
 
@@ -168,53 +188,53 @@ msgstr ""
 msgid "Ignore services list(press OK to save)"
 msgstr ""
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 #, fuzzy
 msgid "Import current source"
 msgstr "Import EPG Źródła"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, fuzzy, python-format
 msgid ""
 "Importing: %s\n"
 "%s events"
 msgstr "Import EPG zakończony, %d wydarzenia"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr ""
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, fuzzy, python-format
 msgid "Last import: %s events"
 msgstr "Ostatnie: %s %s, %d wydarzenia"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Ostatnie: %s %s, %d wydarzenia"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr ""
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Załadować długie opisy do X dni"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manualnie"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr ""
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Nie odnaleziono aktywnych źródeł EPG, nic nie można zrobić"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr ""
 
@@ -222,87 +242,135 @@ msgstr ""
 msgid "Really delete all list?"
 msgstr ""
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr ""
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr ""
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr ""
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr ""
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Pokaż w rozszerzeniach"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 #, fuzzy
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Pokaż w rozszerzeniach"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr ""
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr ""
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Źródła"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Czuwania przy starcie"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Zacznij import po uruchomieniu systemu"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr ""
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr ""
 
-#: ../plugin.py:81
-msgid "Tuesday"
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
 msgstr ""
 
 #: ../plugin.py:82
+msgid "Tuesday"
+msgstr ""
+
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr ""
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Gdy w głębokim trybie gotowości"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr ""
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
 msgstr ""
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/pt.po
+++ b/src/EPGImport/locale/pt.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EpgImporter for enigma2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2017-08-28 18:35+0100\n"
 "Last-Translator: \n"
 "Language-Team: BH-Team\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -26,7 +26,7 @@ msgstr ""
 "Isto pode levar alguns minutos.\n"
 "Confirma?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " eventos\n"
 
@@ -42,19 +42,23 @@ msgstr "Adicionar Operador"
 msgid "All services provider"
 msgstr "Todos os Operadores de Serviços"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Importador EPG automatizado"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Importação automática de EPG"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Hora de início automático"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Cancelar"
 
@@ -62,25 +66,33 @@ msgstr "Cancelar"
 msgid "Channel Selection"
 msgstr "Seleção de Canais"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Escolha de dias para começar a importação"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Limpar"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Limpar o EPG atual antes de importar"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Considere a configuração de \"Perfil de dias\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Perfil de dias"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -90,33 +102,41 @@ msgstr "Eliminar tudo"
 msgid "Delete selected"
 msgstr "Eliminar selecionados"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Configuração de importação EPG"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Log de importação EPG"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Fontes de importação do EPG"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG importação concluída, %d eventos"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Log de importação EPG"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPGImport"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -124,7 +144,7 @@ msgstr ""
 "EPGImport\n"
 "Importação de dados epg ainda está em andamento. Aguarde."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -136,7 +156,7 @@ msgstr ""
 "Isto pode levar alguns minutos.\n"
 "Confirma?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -144,18 +164,18 @@ msgstr ""
 "EPGImport Plugin\n"
 "Falha ao iniciar:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Sexta feira"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Ignorar a lista de serviços"
 
@@ -163,11 +183,11 @@ msgstr "Ignorar a lista de serviços"
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorar a lista de serviços (Premir OK para salvar)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importar a fonte atual"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -176,41 +196,41 @@ msgstr ""
 "Importação: %s\n"
 "%s eventos"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Última importação: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Última importação: %s eventos"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Última: %s %s, %d eventos"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Carregar EPG sómente em bouquets"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Carregar descrições longas de até X dias"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manual"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Segunda-feira"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Sem fontes EPG ativas encontradas, nada a fazer"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Prima OK"
 
@@ -218,80 +238,128 @@ msgstr "Prima OK"
 msgid "Really delete all list?"
 msgstr "Apagar realmente todas as listas?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Desligar a STB após a importação"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Executar AutoTimer após a importação"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Sábado"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Guardar"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Selecionar ação"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Mostrar \"Importador de EPG\" no menu principal"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Mostrar \"EPGImport\" em extensões"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Mostrar registo"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Ignorar a importação na reinicialização do GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Fontes"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Espera na inicialização"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Iniciar importação depois do arranque"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Domingo"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Quinta-Feira"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Terça-Feira"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Quarta-Feira"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Quando em Modo de espera"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Gravar em /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -299,7 +367,7 @@ msgstr ""
 "Não deve usar estas configurações!\n"
 "Pelo menos um dia que por semana deve ser incluída!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/ru.po
+++ b/src/EPGImport/locale/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2016-05-27 22:10+0300\n"
 "Last-Translator: Dimitrij <Dima-73@inbox.lv>\n"
 "Language-Team: LANGUAGE <Dima-73@inbox.lv>\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 1.8.4\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,7 +24,7 @@ msgstr ""
 "Это может занять несколько минут.\n"
 "Это вас устраивает?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " событий\n"
 
@@ -40,19 +40,23 @@ msgstr "Добавить провайдера"
 msgid "All services provider"
 msgstr "Все сервисы провайдера"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Автоматический импортер EPG"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Автоматический импорт EPG"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Начало автоматического старта"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Отмена"
 
@@ -60,25 +64,33 @@ msgstr "Отмена"
 msgid "Channel Selection"
 msgstr "Выбор каналов"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Выбор дней для старта импорта"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Очистка"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Очистка текущего EPG перед импортом"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Учесть настройки \"Профиль дней\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Профиль дней"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -88,32 +100,40 @@ msgstr "Удалить все"
 msgid "Delete selected"
 msgstr "Удалить выбранное"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "EPG импорт - настройки"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "EPG импорт - лог"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Источники импорта EPG"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG импорт закончен, %d событий"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 msgid "EPG import now"
 msgstr "Импорт EPG сейчас"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPG импорт"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -121,7 +141,7 @@ msgstr ""
 "EPG импорт\n"
 "Импорт данных EPG все еще продолжается. Пожалуйста подождите."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -133,7 +153,7 @@ msgstr ""
 "Это может занять несколько минут.\n"
 "Это вас устраивает?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -141,7 +161,7 @@ msgstr ""
 "EPG импорт\n"
 "Ошибка старта:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
@@ -150,11 +170,11 @@ msgstr ""
 "Фильтрация: %s\n"
 "Пожалуйста, подождите!"
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Пятница"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Список игногируемых сервисов"
 
@@ -162,11 +182,11 @@ msgstr "Список игногируемых сервисов"
 msgid "Ignore services list(press OK to save)"
 msgstr "Список игногируемых сервисов (ОК для сохранения)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Импорт текущего источника"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -175,41 +195,41 @@ msgstr ""
 "Импортируем: %s\n"
 "%s событий"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Последний импорт: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Последний импорт: %s событий"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Последний импорт: %s %s, %d событий"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Загрузка EPG только для сервисов из букетов"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Загрузка длинных описаний не больше чем на Х дней"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "В ручную"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Понедельник"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Нет найденных активных источников EPG."
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Нажмите ОК"
 
@@ -217,79 +237,127 @@ msgstr "Нажмите ОК"
 msgid "Really delete all list?"
 msgstr "Удалить весь список?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Возврат в режим глубокого ожидания после импорта"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Запустить Автотаймер по окончании импорта"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Суббота"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Выбор действия"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Показать \"Импорт EPG сейчас\" в главном меню"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Показать \"EPG импорт\" в меню дополнений"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Показать лог"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Пропускать импорт после рестарта GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Источники"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Перейти в режим ожидания после загрузки"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Старт импорта после загрузки"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Воскресенье"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Четверг"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Вторник"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Среда"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Поведение в глубоком ожидании"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Запись в /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -297,7 +365,7 @@ msgstr ""
 "Вы не можете использовать эти настройки!\n"
 "По крайней мере один день недели должен быть активирован!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/sv.po
+++ b/src/EPGImport/locale/sv.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: EPGImport\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2016-12-31 17:00+0100\n"
 "Last-Translator: Jonas Bohdén <jonas@bohden.se>\n"
 "Language-Team: Jonas Bohdén\n"
@@ -14,7 +14,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Poedit-Bookmarks: -1,-1,-1,-1,-1,22,-1,-1,-1,-1\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -26,7 +26,7 @@ msgstr ""
 "Detta kan ta några minuter.\n"
 "Är detta okej?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr "program\n"
 
@@ -42,19 +42,23 @@ msgstr "Lägg till leverantör"
 msgid "All services provider"
 msgstr "Alla kanalleverantörer"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Automatisk EPG-importerare"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Automatisk EPG-importering"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Automatisk starttid"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Avbryt"
 
@@ -62,25 +66,33 @@ msgstr "Avbryt"
 msgid "Channel Selection"
 msgstr "Kanalväljare"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Välj dagar att starta importering"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Rensa"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Rensar nuvarande EPG före importering"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Överväg inställning av \"Dagarprofil\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Dagarprofil"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -90,33 +102,41 @@ msgstr "Radera alla"
 msgid "Delete selected"
 msgstr "Radera valda"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Konfiguration för EPG-importering"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Logg för EPG-importering"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Källor för EPG-importering"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "EPG-importering klar, %d program"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 #, fuzzy
 msgid "EPG import now"
 msgstr "Logg för EPG-importering"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "EPGImport"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -124,7 +144,7 @@ msgstr ""
 "EPGImport\n"
 "Importering av EPG-data pågår fortfarande. Vänligen vänta..."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -136,7 +156,7 @@ msgstr ""
 "Detta kan ta några minuter.\n"
 "Är detta okej?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -144,18 +164,18 @@ msgstr ""
 "EPGImport Plugin\n"
 "Misslyckades att starta:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
 "Please wait!"
 msgstr ""
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "Fredag"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Ignorera kanallistor"
 
@@ -163,11 +183,11 @@ msgstr "Ignorera kanallistor"
 msgid "Ignore services list(press OK to save)"
 msgstr "Ignorera kanallistor (tryck på OK för att spara)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Importera nuvarande källa"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -176,41 +196,41 @@ msgstr ""
 "Importerar: %s\n"
 "%s program"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Senaste importering: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Senaste importering: %s program"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Senast: %s %s, %d program"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Ladda endast EPG för kanaler i kanallistorna"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Ladda långa beskrivningar i upp till X dagar"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Manuellt"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Måndag"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Ingen aktiv EPG-källa hittades, inget att göra"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Tryck OK"
 
@@ -218,80 +238,128 @@ msgstr "Tryck OK"
 msgid "Really delete all list?"
 msgstr "Radera alla listor?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Återgå till djup standby efter importering"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Kör AutoTimer efter importering"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Lördag"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Spara"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Välj åtgärd"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Visa \"EPG-importerare\" i huvudmenyn"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Visa \"EPG-importerare\" i utökningar"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Visa logg"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Hoppa över importering vid omstart av GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Källor"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Standby vid uppstart"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Starta importering efter uppstart"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Söndag"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Torsdag"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Tisdag"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Onsdag"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Vid djup standby"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Skriv till /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -299,7 +367,7 @@ msgstr ""
 "Du får inte använda dessa inställningar!\n"
 "Minst en dag i veckan ska inkluderes!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/locale/uk.po
+++ b/src/EPGImport/locale/uk.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-21 08:48+0200\n"
+"POT-Creation-Date: 2021-04-08 15:25+0200\n"
 "PO-Revision-Date: 2020-05-05 00:12+0300\n"
 "Last-Translator: kvinto <badsystem@ukr.net>\n"
 "Language-Team: kvinto\n"
@@ -12,7 +12,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.2.3\n"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid ""
 "\n"
 "Import of epg data will start.\n"
@@ -24,7 +24,7 @@ msgstr ""
 "Це може зайняти декілька хвилин.\n"
 "Це нормально?"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid " events\n"
 msgstr " передач\n"
 
@@ -40,19 +40,23 @@ msgstr "Додати Провайдер"
 msgid "All services provider"
 msgstr "Всі канали провайдера"
 
-#: ../plugin.py:1001
+#: ../plugin.py:338
+msgid "Also apply \"channel id\" filtering on custom.channels.xml"
+msgstr ""
+
+#: ../plugin.py:1025
 msgid "Automated EPG Importer"
 msgstr "Автозавантаження ЕПГ"
 
-#: ../plugin.py:315
+#: ../plugin.py:323
 msgid "Automatic import EPG"
 msgstr "Автоматичне завантаження ЕПГ"
 
-#: ../plugin.py:316
+#: ../plugin.py:324
 msgid "Automatic start time"
 msgstr "Час автоматичного старту"
 
-#: ../plugin.py:285 ../plugin.py:490 ../plugin.py:569
+#: ../plugin.py:292 ../plugin.py:514 ../plugin.py:593
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -60,25 +64,33 @@ msgstr "Скасувати"
 msgid "Channel Selection"
 msgstr "Вибір Каналів"
 
-#: ../plugin.py:320
+#: ../plugin.py:328
 msgid "Choice days for start import"
 msgstr "Вибір днів для завантаження даних"
 
-#: ../plugin.py:614
+#: ../plugin.py:325
+msgid "Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."
+msgstr ""
+
+#: ../plugin.py:638
 msgid "Clear"
 msgstr "Очистка"
 
-#: ../plugin.py:329
+#: ../plugin.py:337
 msgid "Clearing current EPG before import"
 msgstr "Очищення даних ЕПГ перед завантаженням"
 
-#: ../plugin.py:323
+#: ../plugin.py:331
 msgid "Consider setting \"Days Profile\""
 msgstr "Врахувати налаштування \"Профіль днів\""
 
-#: ../plugin.py:564
+#: ../plugin.py:588
 msgid "Days Profile"
 msgstr "Профіль днів"
+
+#: ../plugin.py:335
+msgid "Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."
+msgstr ""
 
 #: ../filtersServices.py:216
 msgid "Delete all"
@@ -88,32 +100,40 @@ msgstr "Видалити все"
 msgid "Delete selected"
 msgstr "Видалити вибране"
 
-#: ../plugin.py:282
+#: ../plugin.py:334
+msgid "Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."
+msgstr ""
+
+#: ../plugin.py:333
+msgid "Display or not the EPGImport menu in the extension menu."
+msgstr ""
+
+#: ../plugin.py:289
 msgid "EPG Import Configuration"
 msgstr "Налаштування EPG Import"
 
-#: ../plugin.py:638
+#: ../plugin.py:662
 msgid "EPG Import Log"
 msgstr "Лог ЕПГ завантаження"
 
-#: ../plugin.py:525
+#: ../plugin.py:549
 msgid "EPG Import Sources"
 msgstr "Джерело для ЕПГ завантаження"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 #, python-format
 msgid "EPG Import finished, %d events"
 msgstr "Завантаження ЕПГ завершено, %d передач"
 
-#: ../plugin.py:678
+#: ../plugin.py:702
 msgid "EPG import now"
 msgstr "Завантаження ЕПГ в даний момент"
 
-#: ../plugin.py:1003 ../plugin.py:1008
+#: ../plugin.py:1027 ../plugin.py:1032
 msgid "EPGImport"
 msgstr "Завантажувач ЕПГ"
 
-#: ../plugin.py:417
+#: ../plugin.py:441
 msgid ""
 "EPGImport\n"
 "Import of epg data is still in progress. Please wait."
@@ -121,7 +141,7 @@ msgstr ""
 "Завантаження ЕПГ\n"
 "Ще йде завантаження даних ЕПГ. Будь ласка, почекайте."
 
-#: ../plugin.py:433
+#: ../plugin.py:457
 msgid ""
 "EPGImport\n"
 "Import of epg data will start.\n"
@@ -133,7 +153,7 @@ msgstr ""
 "Це може заняти декілька хвилин.\n"
 "Продовжити?"
 
-#: ../plugin.py:442
+#: ../plugin.py:466
 msgid ""
 "EPGImport Plugin\n"
 "Failed to start:\n"
@@ -141,7 +161,7 @@ msgstr ""
 "Завантаження ЕПГ\n"
 "Помилка старту:\n"
 
-#: ../plugin.py:305
+#: ../plugin.py:313
 #, python-format
 msgid ""
 "Filtering: %s\n"
@@ -150,11 +170,11 @@ msgstr ""
 "Фільтр: %s\n"
 "Будь ласка, почекайте!"
 
-#: ../plugin.py:84
+#: ../plugin.py:85
 msgid "Friday"
 msgstr "П’ятниця"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Ignore services list"
 msgstr "Ігнорувати список каналів"
 
@@ -162,11 +182,11 @@ msgstr "Ігнорувати список каналів"
 msgid "Ignore services list(press OK to save)"
 msgstr "Ігнорувати список каналів (ОК для запису)"
 
-#: ../plugin.py:513
+#: ../plugin.py:537
 msgid "Import current source"
 msgstr "Завантажити зараз"
 
-#: ../plugin.py:306
+#: ../plugin.py:314
 #, python-format
 msgid ""
 "Importing: %s\n"
@@ -175,41 +195,41 @@ msgstr ""
 "Йде завантаження: %s\n"
 "%s передач"
 
-#: ../plugin.py:660
+#: ../plugin.py:684
 msgid "Last import: "
 msgstr "Останнє завантаження: "
 
-#: ../plugin.py:412
+#: ../plugin.py:436
 #, python-format
 msgid "Last import: %s events"
 msgstr "Останнє завантаження: %s передач"
 
-#: ../plugin.py:407
+#: ../plugin.py:431
 #, python-format
 msgid "Last: %s %s, %d events"
 msgstr "Останнє завантаження: %s %s, %d передач"
 
-#: ../plugin.py:322
+#: ../plugin.py:330
 msgid "Load EPG only services in bouquets"
 msgstr "Завантаження ЕПГ тільки для каналів з фаворитів"
 
-#: ../plugin.py:327
+#: ../plugin.py:335
 msgid "Load long descriptions up to X days"
 msgstr "Завантаження великих описів передач не більше чим на Х днів"
 
-#: ../plugin.py:287
+#: ../plugin.py:294
 msgid "Manual"
 msgstr "Вручну"
 
-#: ../plugin.py:80
+#: ../plugin.py:81
 msgid "Monday"
 msgstr "Понеділок"
 
-#: ../plugin.py:428
+#: ../plugin.py:452
 msgid "No active EPG sources found, nothing to do"
 msgstr "Не знайдено активних ЕПГ джерел"
 
-#: ../plugin.py:72
+#: ../plugin.py:73
 msgid "Press OK"
 msgstr "Натисніть ОК"
 
@@ -217,80 +237,128 @@ msgstr "Натисніть ОК"
 msgid "Really delete all list?"
 msgstr "Дійсно видалити весь список?"
 
-#: ../plugin.py:318
+#: ../plugin.py:326
 msgid "Return to deep standby after import"
 msgstr "Повернутися до режиму очікування після завантаження даних"
 
-#: ../plugin.py:328
+#: ../plugin.py:336
 msgid "Run AutoTimer after import"
 msgstr "Запустити AutoTimer після завантаження"
 
-#: ../plugin.py:85
+#: ../plugin.py:86
 msgid "Saturday"
 msgstr "Субота"
 
-#: ../plugin.py:286 ../plugin.py:491 ../plugin.py:570 ../plugin.py:617
+#: ../plugin.py:293 ../plugin.py:515 ../plugin.py:594 ../plugin.py:641
 msgid "Save"
 msgstr "Зберегти"
 
-#: ../filtersServices.py:266 ../plugin.py:456
+#: ../plugin.py:480 ../filtersServices.py:266
 msgid "Select action"
 msgstr "Виберіть дію"
 
-#: ../plugin.py:326
+#: ../plugin.py:334
 #, fuzzy
 msgid "Show \"EPG import now\" in main menu"
 msgstr "Показати \"EPG Import\" в головному меню"
 
-#: ../plugin.py:325
+#: ../plugin.py:333
 msgid "Show \"EPGImport\" in extensions"
 msgstr "Показати \"EPG import\" в меню плагінів"
 
-#: ../plugin.py:455
+#: ../plugin.py:479
 msgid "Show log"
 msgstr "Показати лог"
 
-#: ../plugin.py:324
+#: ../plugin.py:332
 msgid "Skip import on restart GUI"
 msgstr "Не завантажувати після рестарту GUI"
 
-#: ../plugin.py:288
+#: ../plugin.py:295
 msgid "Sources"
 msgstr "Джерела"
 
-#: ../plugin.py:319
+#: ../plugin.py:329
+msgid "Specify in which case the EPG must be automatically updated after the box has booted."
+msgstr ""
+
+#: ../plugin.py:324
+msgid "Specify the time for the automatic EPG update."
+msgstr ""
+
+#: ../plugin.py:327
 msgid "Standby at startup"
 msgstr "Перейти в режим очікування після завантаження"
 
-#: ../plugin.py:321
+#: ../plugin.py:329
 msgid "Start import after booting up"
 msgstr "Завантажити після включення"
 
-#: ../plugin.py:86
+#: ../plugin.py:87
 msgid "Sunday"
 msgstr "Неділя"
 
-#: ../plugin.py:83
+#: ../plugin.py:327
+msgid "The waked up box will be turned into standby after automatic EPG import wake up."
+msgstr ""
+
+#: ../plugin.py:337
+msgid "This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."
+msgstr ""
+
+#: ../plugin.py:326
+msgid "This will turn back waked up box into deep-standby after automatic EPG import."
+msgstr ""
+
+#: ../plugin.py:84
 msgid "Thursday"
 msgstr "Четвер"
 
-#: ../plugin.py:81
+#: ../plugin.py:330
+msgid "To save memory you can decide to only load EPG data for the services that you have in your bouquet files."
+msgstr ""
+
+#: ../plugin.py:82
 msgid "Tuesday"
 msgstr "Вівторок"
 
-#: ../plugin.py:82
+#: ../plugin.py:83
 msgid "Wednesday"
 msgstr "Середа"
 
-#: ../plugin.py:317
+#: ../plugin.py:323
+msgid "When enabled, it allows you to schedule an automatic EPG update at the given days and time."
+msgstr ""
+
+#: ../plugin.py:325
 msgid "When in deep standby"
 msgstr "Дія в глибокому режимі очікування"
 
-#: ../plugin.py:644
+#: ../plugin.py:338
+msgid "When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."
+msgstr ""
+
+#: ../plugin.py:331
+msgid "When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."
+msgstr ""
+
+#: ../plugin.py:332
+msgid "When you restart the GUI you can decide to skip or not the EPG data import."
+msgstr ""
+
+#: ../plugin.py:668
 msgid "Write to /tmp/epgimport.log"
 msgstr "Записати в /tmp/epgimport.log"
 
-#: ../plugin.py:589
+#: ../plugin.py:328
+msgid "You can select the day(s) when the EPG update must be performed."
+msgstr ""
+
+#: ../plugin.py:336
+msgid "You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."
+msgstr ""
+
+#: ../plugin.py:613
 msgid ""
 "You may not use this settings!\n"
 "At least one day a week should be included!"
@@ -298,7 +366,7 @@ msgstr ""
 "Ви не можете використовувати дані налаштування!\n"
 "Хоча б один день тижня повинен бути активований!"
 
-#: ../plugin.py:706
+#: ../plugin.py:730
 msgid ""
 "You must restart Enigma2 to load the EPG data,\n"
 "is this OK?"

--- a/src/EPGImport/plugin.py
+++ b/src/EPGImport/plugin.py
@@ -69,6 +69,7 @@ config.plugins.epgimport.deepstandby_afterimport = NoSave(ConfigYesNo(default=Fa
 config.plugins.epgimport.parse_autotimer = ConfigYesNo(default=False)
 config.plugins.epgimport.import_onlybouquet = ConfigYesNo(default=False)
 config.plugins.epgimport.clear_oldepg = ConfigYesNo(default=False)
+config.plugins.epgimport.filter_custom_channel = ConfigYesNo(default=True)
 config.plugins.epgimport.day_profile = ConfigSelection(choices=[("1", _("Press OK"))], default="1")
 config.plugins.extra_epgimport = ConfigSubsection()
 config.plugins.extra_epgimport.last_import = ConfigText(default="0")
@@ -216,6 +217,10 @@ lastImportResult = None
 
 def startImport():
 	EPGImport.HDD_EPG_DAT = config.misc.epgcache_filename.value
+	if config.plugins.epgimport.filter_custom_channel.value:
+		EPGConfig.filterCustomChannel = True
+	else:
+		EPGConfig.filterCustomChannel = False
 	if config.plugins.epgimport.clear_oldepg.value and hasattr(epgimport.epgcache, 'flushEPG'):
 		EPGImport.unlink_if_exists(EPGImport.HDD_EPG_DAT)
 		EPGImport.unlink_if_exists(EPGImport.HDD_EPG_DAT + '.backup')
@@ -252,6 +257,7 @@ class EPGImportConfig(ConfigListScreen, Screen):
 				<widget font="Regular;18" halign="left" position="545,480" render="Label" size="55,20" source="global.CurrentTime" transparent="1" valign="center" zPosition="3">
 					<convert type="ClockToText">Default</convert>
 				</widget>
+				<widget name="description" position="10,400" size="590,150" itemHeight="18" font="Regular;18" valign="top"/>
 				<widget name="statusbar" position="10,480" size="500,20" font="Regular;18" />
 				<widget name="status" position="10,400" size="580,60" font="Regular;20" />
 			</screen>"""
@@ -273,6 +279,7 @@ class EPGImportConfig(ConfigListScreen, Screen):
 				<widget font="Regular;18" halign="left" position="545,400" render="Label" size="55,20" source="global.CurrentTime" transparent="1" valign="center" zPosition="3">
 					<convert type="ClockToText">Default</convert>
 				</widget>
+				<widget name="description" position="10,315" size="590,75" itemHeight="18" font="Regular;18" valign="top"/>
 				<widget name="statusbar" position="10,410" size="500,20" font="Regular;18" />
 				<widget name="status" position="10,330" size="580,60" font="Regular;20" />
 			</screen>"""
@@ -286,6 +293,7 @@ class EPGImportConfig(ConfigListScreen, Screen):
 		self["key_green"] = Button(_("Save"))
 		self["key_yellow"] = Button(_("Manual"))
 		self["key_blue"] = Button(_("Sources"))
+		self["description"] = Label("")
 		self["setupActions"] = ActionMap(["SetupActions", "ColorActions", "TimerEditActions", "MovieSelectionActions"],
 		{
 			"red": self.keyCancel,
@@ -312,50 +320,66 @@ class EPGImportConfig(ConfigListScreen, Screen):
 
 	def initConfig(self):
 		self.EPG = config.plugins.epgimport
-		self.cfg_enabled = getConfigListEntry(_("Automatic import EPG"), self.EPG.enabled)
-		self.cfg_wakeup = getConfigListEntry(_("Automatic start time"), self.EPG.wakeup)
-		self.cfg_deepstandby = getConfigListEntry(_("When in deep standby"), self.EPG.deepstandby)
-		self.cfg_shutdown = getConfigListEntry(_("Return to deep standby after import"), self.EPG.shutdown)
-		self.cfg_standby_afterwakeup = getConfigListEntry(_("Standby at startup"), self.EPG.standby_afterwakeup)
-		self.cfg_day_profile = getConfigListEntry(_("Choice days for start import"), self.EPG.day_profile)
-		self.cfg_runboot = getConfigListEntry(_("Start import after booting up"), self.EPG.runboot)
-		self.cfg_import_onlybouquet = getConfigListEntry(_("Load EPG only services in bouquets"), self.EPG.import_onlybouquet)
-		self.cfg_runboot_day = getConfigListEntry(_("Consider setting \"Days Profile\""), self.EPG.runboot_day)
-		self.cfg_runboot_restart = getConfigListEntry(_("Skip import on restart GUI"), self.EPG.runboot_restart)
-		self.cfg_showinextensions = getConfigListEntry(_("Show \"EPGImport\" in extensions"), self.EPG.showinextensions)
-		self.cfg_showinmainmenu = getConfigListEntry(_("Show \"EPG import now\" in main menu"), self.EPG.showinmainmenu)
-		self.cfg_longDescDays = getConfigListEntry(_("Load long descriptions up to X days"), self.EPG.longDescDays)
-		self.cfg_parse_autotimer = getConfigListEntry(_("Run AutoTimer after import"), self.EPG.parse_autotimer)
-		self.cfg_clear_oldepg = getConfigListEntry(_("Clearing current EPG before import"), config.plugins.epgimport.clear_oldepg)
+		self.cfg_enabled = getConfigListEntry(_("Automatic import EPG"), self.EPG.enabled, _("When enabled, it allows you to schedule an automatic EPG update at the given days and time."))
+		self.cfg_wakeup = getConfigListEntry(_("Automatic start time"), self.EPG.wakeup, _("Specify the time for the automatic EPG update."))
+		self.cfg_deepstandby = getConfigListEntry(_("When in deep standby"), self.EPG.deepstandby, _("Choose the action to perform when the box is in deep standby and the automatic EPG update should normally start."))
+		self.cfg_shutdown = getConfigListEntry(_("Return to deep standby after import"), self.EPG.shutdown, _("This will turn back waked up box into deep-standby after automatic EPG import."))
+		self.cfg_standby_afterwakeup = getConfigListEntry(_("Standby at startup"), self.EPG.standby_afterwakeup, _("The waked up box will be turned into standby after automatic EPG import wake up."))
+		self.cfg_day_profile = getConfigListEntry(_("Choice days for start import"), self.EPG.day_profile, _("You can select the day(s) when the EPG update must be performed."))
+		self.cfg_runboot = getConfigListEntry(_("Start import after booting up"), self.EPG.runboot, _("Specify in which case the EPG must be automatically updated after the box has booted."))
+		self.cfg_import_onlybouquet = getConfigListEntry(_("Load EPG only services in bouquets"), self.EPG.import_onlybouquet, _("To save memory you can decide to only load EPG data for the services that you have in your bouquet files."))
+		self.cfg_runboot_day = getConfigListEntry(_("Consider setting \"Days Profile\""), self.EPG.runboot_day, _("When you decide to load the EPG after GUI restart mention if the \"days profile\" must be take into consideration or not."))
+		self.cfg_runboot_restart = getConfigListEntry(_("Skip import on restart GUI"), self.EPG.runboot_restart,_("When you restart the GUI you can decide to skip or not the EPG data import."))
+		self.cfg_showinextensions = getConfigListEntry(_("Show \"EPGImport\" in extensions"), self.EPG.showinextensions, _("Display or not the EPGImport menu in the extension menu."))
+		self.cfg_showinmainmenu = getConfigListEntry(_("Show \"EPG import now\" in main menu"), self.EPG.showinmainmenu, _("Display a shortcut \"EPG import now\" on your STB main screen. This menu entry will immediately start the EPG update process when selected."))
+		self.cfg_longDescDays = getConfigListEntry(_("Load long descriptions up to X days"), self.EPG.longDescDays, _("Define the number of days that you want to get the full EPG data, reducing this number can help you to save memory usage on your box. But you are also limited with the EPG provider available data. You will not have 15 days EPG if it only provide 7 days data."))
+		self.cfg_parse_autotimer = getConfigListEntry(_("Run AutoTimer after import"), self.EPG.parse_autotimer, _("You can start automatically the plugin AutoTimer after the EPG data update to have it refreshing its scheduling after EPG data refresh."))
+		self.cfg_clear_oldepg = getConfigListEntry(_("Clearing current EPG before import"), config.plugins.epgimport.clear_oldepg, _("This will clear the current EPG data in memory before updating the EPG data. This allows you to always have a clean new EPG with the latest EPG data, for example in case of program changes between refresh, otherwise EPG data are cumulative."))
+		self.cfg_filter_custom_channel =  getConfigListEntry(_("Also apply \"channel id\" filtering on custom.channels.xml"), self.EPG.filter_custom_channel, _("When the file /etc/epgimport/channel_id_filter.conf exists with valid regular expression in, its content will always be applied as filter to all the EPG data files. But you can decide if it should be applied too or not on your /etc/epgimport/custom.channels.xml."))
 
 	def createSetup(self):
-		list = [self.cfg_enabled]
+		self.list = [self.cfg_enabled]
 		if self.EPG.enabled.value:
-			list.append(self.cfg_wakeup)
-			list.append(self.cfg_deepstandby)
+			self.list.append(self.cfg_wakeup)
+			self.list.append(self.cfg_deepstandby)
 			if self.EPG.deepstandby.value == "wakeup":
-				list.append(self.cfg_shutdown)
+				self.list.append(self.cfg_shutdown)
 				if not self.EPG.shutdown.value:
-					list.append(self.cfg_standby_afterwakeup)
-		list.append(self.cfg_day_profile)
-		list.append(self.cfg_runboot)
+					self.list.append(self.cfg_standby_afterwakeup)
+		self.list.append(self.cfg_day_profile)
+		self.list.append(self.cfg_runboot)
 		if self.EPG.runboot.value != "4":
-			list.append(self.cfg_runboot_day)
+			self.list.append(self.cfg_runboot_day)
 			if self.EPG.runboot.value == "1" or self.EPG.runboot.value == "2":
-				list.append(self.cfg_runboot_restart)
-		list.append(self.cfg_showinextensions)
-		list.append(self.cfg_showinmainmenu)
-		list.append(self.cfg_import_onlybouquet)
+				self.list.append(self.cfg_runboot_restart)
+		self.list.append(self.cfg_showinextensions)
+		self.list.append(self.cfg_showinmainmenu)
+		self.list.append(self.cfg_import_onlybouquet)
 		if hasattr(enigma.eEPGCache, 'flushEPG'):
-			list.append(self.cfg_clear_oldepg)
-		list.append(self.cfg_longDescDays)
+			self.list.append(self.cfg_clear_oldepg)
+		self.list.append(self.cfg_filter_custom_channel)
+		self.list.append(self.cfg_longDescDays)
 		if fileExists(resolveFilename(SCOPE_PLUGINS, "Extensions/AutoTimer/plugin.py")):
 			try:
 				from Plugins.Extensions.AutoTimer.AutoTimer import AutoTimer
-				list.append(self.cfg_parse_autotimer)
+				self.list.append(self.cfg_parse_autotimer)
 			except:
 				print>>log, "[EPGImport] AutoTimer Plugin not installed"
-		self["config"].setList(list)
+		self["config"].list = self.list
+		self["config"].setList(self.list)
+
+	# for summary:
+	def getCurrentEntry(self):
+		self.updateDescription()
+		return ConfigListScreen.getCurrentEntry(self)
+
+	def createSummary(self):
+		from Screens.Setup import SetupSummary
+		return SetupSummary
+
+	def updateDescription(self):
+		self["description"].setText(self.getCurrentDescription())
+	###
 
 	def newConfig(self):
 		cur = self["config"].getCurrent()

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,7 +6,7 @@ dreamcrc = Extension('Extensions/EPGImport/dreamcrc', sources=['dreamcrc.c'])
 
 pkg = 'Extensions.EPGImport'
 setup (name='enigma2-plugin-extensions-xmltvimport',
-		version='0.9.12',
+		version='0.9.13',
 		description='C implementation of Dream CRC32 algorithm',
 		package_dir={pkg: 'EPGImport'},
 		packages=[pkg],


### PR DESCRIPTION
Some channels share the same service reference but have multiple languages available for there EPG.
Today it is always the latest loaded EPG data file that will push its language and you have no easy control on this download order.
The current solution is to totally exclude the downloading of an EPG package file but this not always possible (for exemple news channels are all in the same file).

<!-- DK --> <!-- 0.8W --> <channel id=" DiscoveryHD.dk "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
<!-- FI --> <!-- 0.8W --> <channel id=" DiscoveryHD.fi "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
<!-- HRV --> <!-- 0.8W --> <channel id=" DiscoveryHDShowcase.rs "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
<!-- HU --> <!-- 0.8W --> <channel id=" DiscoveryHDShowcase.hu "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
<!-- NO --> <!-- 0.8W --> <channel id=" DiscoveryChannel.no "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
<!-- SE --> <!-- 0.8W --> <channel id=" DiscoveryHDshowcase.se "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  Discovery HD Showcase  -->
<!-- SVN --> <!-- 0.8W --> <channel id=" DiscoveryHD.svn "> 1:0:19:1006:29:46:E080000:0:0:0: </channel><!--  HD Discovery Shovcase  -->

All the same service ref, but different language EPG attached.

It was requested to find a mechanism to filter out some specific or group of channel id.


Solution:

You can now create a file /etc/epgimport/channel_id_filter.conf

this file will containt one regular expression per line, a logical OR operation will be performed between every regular expression (regex) lines.
There are many tutorials about regex on the internet. But here is some basis for you:

. means any characters but only once
* means 0 or more characters
+ means 1 or more characters
\. means the dot itself (since . means any characters)
^ start of the string
$ means end of the string
.* will replace any characters

The filters are turned into lower case because the channel id are also always turned into lower case in EPGImport
So FR, Fr, fR will anyway be turned into: fr

So if you want to exclude every french channel id use
.*\.fr
This means any string ending by .fr will be filtered out

Remark:  
-> *\.fr is not a valid regex because * means that the preceding char should repeated several times but you don't specify any, so .* is the correct syntax. Remember . means any char but . only means only one time any char.
-> Invalid regex will simply be ignored (it will be mentionned in the EPGImport log) but this won't prevent the EPG loading.
-> Too wide regex will filter out more than you expect, for example if you define just .* you will have no EPG because everything will be filtered out. So use wildcard with caution. If you are not familiar with regex use the fixed syntax: ChannelIDName\.Extension


You can also specify the single channel id example:    discoveryhd\.dk   will only match the channel id="DiscoveryHD.dk" (remember the channel id is turned into lowercase).
If you decide to exclude all the .dk channel id you can simply specify:  .*\.dk

The filter will apply to every possible channels.xml files so once you define an exclusion it will be use globally. You can only control the filtering on the /etc/epgimport/custom_channels.xml file.