### PR TITLE
[xmltvconverter] Fix get_xml_string method:

### DIFF
--- a/src/EPGImport/xmltvconverter.py
+++ b/src/EPGImport/xmltvconverter.py
@@ -37,7 +37,7 @@ def get_xml_string(elem, name):
 		for node in elem.findall(name):
 			txt = node.text
 			lang = node.get('lang', None)
-			if not r:
+			if not r and txt is not None:
 				r = txt
 			elif lang == "nl":
 				r = txt


### PR DESCRIPTION
```
<programme channel="Akv&#225;rium" start="20211030180000 +0200"
stop="20211030190000 +0200">
       <title lang="cs">Akv&#225;rium</title>
       <desc lang="cs" />
</programme>
```

When get_xml_string was run with "desc" argument on the element above
it expected that the text was set for the element, which is not the case.

So elements like these were dropped from possible EPG lookup with error message:
```
[XMLTVConverter] parsing event error: 'NoneType' object has no attribute
'replace'
```
It is because unescape was run on NoneType object inside get_xml_string,
which raised the exception. To fix this, r variable will be not
reassigned to NoneType but it will stay as '' if text is None
so unescape will not cause crash and element will be considered in
EPG lookup.