### PR TITLE
EPGImport: decode url to string

### DIFF
--- a/src/EPGImport/EPGImport.py
+++ b/src/EPGImport/EPGImport.py
@@ -449,10 +449,10 @@ class EPGImport:
 		if ext and len(ext) < 6:
 			filename += ext
 		sourcefile = sourcefile.encode('utf-8')
-		sslcf = SNIFactory(sourcefile) if sourcefile.startswith('https:') else None
-		print("[EPGImport] Downloading: " + sourcefile + " to local path: " + filename, file=log)
+		sslcf = SNIFactory(sourcefile) if sourcefile.decode().startswith('https:') else None
+		print("[EPGImport] Downloading: " + sourcefile.decode() + " to local path: " + filename, file=log)
 		if self.source.nocheck == 1:
-			print("[EPGImport] Not cheching the server since nocheck is set for it: " + sourcefile, file=log)
+			print("[EPGImport] Not cheching the server since nocheck is set for it: " + sourcefile.decode(), file=log)
 			downloadPage(sourcefile, filename, contextFactory=sslcf).addCallbacks(afterDownload, downloadFail, callbackArgs=(filename, True))
 			return filename
 		else:


### PR DESCRIPTION
In python3 we need to make sure that string functions work with string.
So an extra decode is required to convert bytes to string.

This commit fixes the following errors in python3:
[EPGImport] Error at start: startswith first arg must be bytes or a tuple of bytes, not str
[EPGImport] Error at start: can only concatenate str (not "bytes") to str