### PR TITLE
xmltvconverter: use six to handle both python2,3

### DIFF
--- a/src/EPGImport/xmltvconverter.py
+++ b/src/EPGImport/xmltvconverter.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import six
 import calendar
 import time
 from xml.etree.cElementTree import iterparse
@@ -56,7 +57,7 @@ def get_xml_string(elem, name):
 		r"&#91;" : r"[",
 		r"&#93;" : r"]",
 	})
-	return r.encode('utf-8')
+	return six.ensure_str(r)
 
 
 def enumerateProgrammes(fp):


### PR DESCRIPTION
Use six.ensure_str to handle python2 with encode utf-8 and python3
that is always utf-8.