### PR TITLE
EPGImport.py: Fix crash manual import

### DIFF
--- a/src/EPGImport/EPGImport.py
+++ b/src/EPGImport/EPGImport.py
@@ -8,6 +8,7 @@ import gzip
 import os
 import random
 import time
+import six
 from datetime import datetime
 
 import twisted.python.runtime
@@ -138,7 +139,7 @@ class EPGImport:
 	def checkValidServer(self, serverurl):
 		print("[EPGImport] checkValidServer serverurl %s" % serverurl, file=log)
 		dirname, filename = os.path.split(serverurl)
-		FullString = dirname + "/" + CheckFile
+		FullString = dirname + b"/" + six.ensure_binary(CheckFile)
 		req = build_opener()
 		req.addheaders = [('User-Agent', 'Twisted Client')]
 		dlderror = 0


### PR DESCRIPTION
EPGImport] nextImport, source= News Channels (xz)
[EPGImport] Downloading: http://rytecepg.dyndns.tv/epg_data/rytecNWS.xz to local path: /tmp/epgimport.xz
[EPGImport] checkValidServer serverurl b'http://rytecepg.dyndns.tv/epg_data/rytecNWS.xz'
[EPGImport] Error at start: can't concat str to bytes