### PR TITLE
[EPGConfig] sanity check local file os.path.getmtime

### DIFF
--- a/src/EPGImport/EPGConfig.py
+++ b/src/EPGImport/EPGConfig.py
@@ -168,8 +168,11 @@ class EPGChannel:
 			self.mtime = time.time()
 			return self.parse(filterCallback, downloadedFile, True)
 		elif (len(self.urls) == 1) and isLocalFile(self.urls[0]):
-			mtime = os.path.getmtime(self.urls[0])
-			if (not self.mtime) or (self.mtime < mtime):
+			try:
+				mtime = os.path.getmtime(self.urls[0])
+			except:
+				mtime = None
+			if (not self.mtime) or (mtime is not None and self.mtime < mtime):
 				self.parse(filterCallback, self.urls[0], True)
 				self.mtime = mtime
 


### PR DESCRIPTION
-if the local file does not exist the EPG import will never end with the text "Importing: 0 events",so need restart E2